### PR TITLE
refactor/#12/selectable ai service provider

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,7 +31,9 @@
     "csv-parse": "^5.6.0",
     "jsonwebtoken": "^9.0.3",
     "livekit-server-sdk": "^2.15.0",
+    "@aws-sdk/client-bedrock-runtime": "^3.734.0",
     "openai": "^4.77.0",
+
     "pg": "^8.13.1",
     "reflect-metadata": "^0.2.2",
     "rxjs": "^7.8.1"

--- a/src/ai/ai.constants.ts
+++ b/src/ai/ai.constants.ts
@@ -1,0 +1,18 @@
+export const DEFAULT_AI_INSTRUCTION = `당신은 어르신과 AI(다미)의 대화를 분석하는 전문가입니다.`;
+
+export const AI_RESPONSE_SCHEMA = `
+다음 JSON 형식으로 분석 결과를 반환해주세요:
+{
+  "summary": "대화 요약 (2-3문장, 한국어)",
+  "mood": "positive" | "neutral" | "negative",
+  "moodScore": 0.0 ~ 1.0 (감정 점수, 1이 가장 긍정적),
+  "tags": ["키워드1", "키워드2", ...] (최대 5개, 한국어),
+  "healthKeywords": {
+    "pain": 언급 횟수 (숫자) 또는 null,
+    "sleep": "good" | "bad" | "mentioned" 또는 null,
+    "meal": "regular" | "irregular" | "mentioned" 또는 null,
+    "medication": "compliant" | "non-compliant" | "mentioned" 또는 null
+  }
+}`;
+
+export const DEFAULT_SYSTEM_PROMPT = `${DEFAULT_AI_INSTRUCTION}\n${AI_RESPONSE_SCHEMA}`;

--- a/src/ai/ai.interface.ts
+++ b/src/ai/ai.interface.ts
@@ -1,0 +1,5 @@
+import { CallAnalysisResult } from './types';
+
+export interface AiAnalysisProvider {
+  analyze(transcript: string): Promise<CallAnalysisResult>;
+}

--- a/src/ai/ai.interface.ts
+++ b/src/ai/ai.interface.ts
@@ -1,5 +1,6 @@
 import { CallAnalysisResult } from './types';
 
-export interface AiAnalysisProvider {
-  analyze(transcript: string): Promise<CallAnalysisResult>;
+export abstract class AiAnalysisProvider {
+  abstract analyze(transcript: string): Promise<CallAnalysisResult>;
 }
+

--- a/src/ai/ai.module.ts
+++ b/src/ai/ai.module.ts
@@ -1,6 +1,7 @@
 import { Module, Global } from '@nestjs/common';
 import { AiService } from './ai.service';
 import { OpenAiProvider } from './providers/openai.provider';
+import { BedrockProvider } from './providers/bedrock.provider';
 
 export const AI_PROVIDER = 'AI_PROVIDER';
 
@@ -17,7 +18,21 @@ export const AI_PROVIDER = 'AI_PROVIDER';
     {
       provide: AI_PROVIDER,
       useFactory: () => {
-        return new OpenAiProvider(process.env.OPENAI_API_KEY);
+        const providerType = process.env.AI_PROVIDER || 'bedrock';
+
+        if (providerType === 'bedrock') {
+          return new BedrockProvider(
+            process.env.AWS_REGION,
+            process.env.AWS_ACCESS_KEY_ID,
+            process.env.AWS_SECRET_ACCESS_KEY,
+            process.env.BEDROCK_MODEL,
+          );
+        }
+
+        return new OpenAiProvider(
+          process.env.OPENAI_API_KEY,
+          process.env.OPENAI_MODEL,
+        );
       },
     },
   ],

--- a/src/ai/ai.module.ts
+++ b/src/ai/ai.module.ts
@@ -1,10 +1,9 @@
 import { Module, Global } from '@nestjs/common';
 import { AiService } from './ai.service';
+import { AiAnalysisProvider } from './ai.interface';
 import { OpenAiProvider } from './providers/openai.provider';
 import { BedrockProvider } from './providers/bedrock.provider';
 import { DEFAULT_AI_INSTRUCTION, AI_RESPONSE_SCHEMA } from './ai.constants';
-
-export const AI_PROVIDER = 'AI_PROVIDER';
 
 /**
  * AI 모듈
@@ -17,7 +16,7 @@ export const AI_PROVIDER = 'AI_PROVIDER';
   providers: [
     AiService,
     {
-      provide: AI_PROVIDER,
+      provide: AiAnalysisProvider,
       useFactory: () => {
         const providerType = process.env.AI_PROVIDER || 'bedrock';
         const maxTokens = parseInt(process.env.AI_MAX_TOKENS || '1000', 10);

--- a/src/ai/ai.module.ts
+++ b/src/ai/ai.module.ts
@@ -1,5 +1,8 @@
 import { Module, Global } from '@nestjs/common';
 import { AiService } from './ai.service';
+import { OpenAiProvider } from './providers/openai.provider';
+
+export const AI_PROVIDER = 'AI_PROVIDER';
 
 /**
  * AI 모듈
@@ -9,7 +12,15 @@ import { AiService } from './ai.service';
  */
 @Global()
 @Module({
-  providers: [AiService],
+  providers: [
+    AiService,
+    {
+      provide: AI_PROVIDER,
+      useFactory: () => {
+        return new OpenAiProvider(process.env.OPENAI_API_KEY);
+      },
+    },
+  ],
   exports: [AiService],
 })
 export class AiModule {}

--- a/src/ai/ai.module.ts
+++ b/src/ai/ai.module.ts
@@ -2,6 +2,7 @@ import { Module, Global } from '@nestjs/common';
 import { AiService } from './ai.service';
 import { OpenAiProvider } from './providers/openai.provider';
 import { BedrockProvider } from './providers/bedrock.provider';
+import { DEFAULT_AI_INSTRUCTION, AI_RESPONSE_SCHEMA } from './ai.constants';
 
 export const AI_PROVIDER = 'AI_PROVIDER';
 
@@ -19,6 +20,10 @@ export const AI_PROVIDER = 'AI_PROVIDER';
       provide: AI_PROVIDER,
       useFactory: () => {
         const providerType = process.env.AI_PROVIDER || 'bedrock';
+        const maxTokens = parseInt(process.env.AI_MAX_TOKENS || '1000', 10);
+        const instruction =
+          process.env.AI_INSTRUCTION || DEFAULT_AI_INSTRUCTION;
+        const systemPrompt = `${instruction}\n${AI_RESPONSE_SCHEMA}`;
 
         if (providerType === 'bedrock') {
           return new BedrockProvider(
@@ -26,12 +31,16 @@ export const AI_PROVIDER = 'AI_PROVIDER';
             process.env.AWS_ACCESS_KEY_ID,
             process.env.AWS_SECRET_ACCESS_KEY,
             process.env.BEDROCK_MODEL,
+            maxTokens,
+            systemPrompt,
           );
         }
 
         return new OpenAiProvider(
           process.env.OPENAI_API_KEY,
           process.env.OPENAI_MODEL,
+          maxTokens,
+          systemPrompt,
         );
       },
     },

--- a/src/ai/ai.module.ts
+++ b/src/ai/ai.module.ts
@@ -28,6 +28,11 @@ import { DEFAULT_AI_INSTRUCTION, AI_RESPONSE_SCHEMA } from './ai.constants';
         }
 
         const maxTokens = parseInt(process.env.AI_MAX_TOKENS || '2000', 10);
+        if (isNaN(maxTokens) || maxTokens <= 0) {
+          throw new Error(
+            `Invalid AI_MAX_TOKENS: ${process.env.AI_MAX_TOKENS}. Must be a positive number.`,
+          );
+        }
 
         const instruction =
           process.env.AI_INSTRUCTION || DEFAULT_AI_INSTRUCTION;

--- a/src/ai/ai.service.ts
+++ b/src/ai/ai.service.ts
@@ -1,7 +1,6 @@
-import { Injectable, Logger, Inject } from '@nestjs/common';
+import { Injectable, Logger } from '@nestjs/common';
 import { DbService } from '../database';
-import { AI_PROVIDER } from './ai.module';
-import type { AiAnalysisProvider } from './ai.interface';
+import { AiAnalysisProvider } from './ai.interface';
 import { AnalyzeCallResult, AiResponse } from './types';
 
 @Injectable()
@@ -10,7 +9,7 @@ export class AiService {
 
   constructor(
     private readonly dbService: DbService,
-    @Inject(AI_PROVIDER) private readonly aiProvider: AiAnalysisProvider,
+    private readonly aiProvider: AiAnalysisProvider,
   ) {}
 
   async analyzeCall(callId: string): Promise<AnalyzeCallResult> {

--- a/src/ai/ai.service.ts
+++ b/src/ai/ai.service.ts
@@ -22,8 +22,17 @@ export class AiService {
       throw new Error(`Call not found: ${callId}`);
     }
 
+    if (!callInfo.transcript) {
+      this.logger.warn(`No transcript found for callId=${callId}`);
+      return {
+        success: false,
+        callId,
+        error: 'No transcript available',
+      };
+    }
+
     // 2. AI 분석
-    const analysis = await this.aiProvider.analyze(callInfo.transcript || '');
+    const analysis = await this.aiProvider.analyze(callInfo.transcript);
 
     if (!analysis.success) {
       this.logger.warn(

--- a/src/ai/ai.service.ts
+++ b/src/ai/ai.service.ts
@@ -1,49 +1,17 @@
-import { Injectable, Logger } from '@nestjs/common';
-import OpenAI from 'openai';
+import { Injectable, Logger, Inject } from '@nestjs/common';
 import { DbService } from '../database';
-
-type CallAnalysisResult = {
-  summary: string;
-  mood: 'positive' | 'neutral' | 'negative';
-  moodScore: number;
-  tags: string[];
-  healthKeywords: {
-    pain: number | null;
-    sleep: string | null;
-    meal: string | null;
-    medication: string | null;
-  };
-};
-
-type AnalyzeCallResult = {
-  callId: string;
-  wardId: string | null;
-  summary: string;
-  mood: string;
-  moodScore: number;
-  tags: string[];
-  healthKeywords: Record<string, unknown>;
-  duration: number | null;
-  createdAt: string;
-};
+import { AI_PROVIDER } from './ai.module';
+import type { AiAnalysisProvider } from './ai.interface';
+import { CallAnalysisResult, AnalyzeCallResult } from './types';
 
 @Injectable()
 export class AiService {
   private readonly logger = new Logger(AiService.name);
-  private readonly openai: OpenAI | null;
 
-  constructor(private readonly dbService: DbService) {
-    const apiKey = process.env.OPENAI_API_KEY;
-    if (apiKey) {
-      this.openai = new OpenAI({ apiKey });
-      this.logger.log('OpenAI client initialized');
-    } else {
-      this.openai = null;
-      this.logger.warn(
-        'OPENAI_API_KEY not set, AI analysis will use mock data',
-      );
-    }
-  }
+  constructor(
+    private readonly dbService: DbService,
+    @Inject(AI_PROVIDER) private readonly aiProvider: AiAnalysisProvider,
+  ) {}
 
   async analyzeCall(callId: string): Promise<AnalyzeCallResult> {
     this.logger.log(`analyzeCall callId=${callId}`);
@@ -55,12 +23,7 @@ export class AiService {
     }
 
     // 2. AI 분석 (또는 Mock)
-    let analysis: CallAnalysisResult;
-    if (this.openai) {
-      analysis = await this.analyzeWithOpenAI(callInfo.transcript || '');
-    } else {
-      analysis = this.getMockAnalysis();
-    }
+    const analysis = await this.aiProvider.analyze(callInfo.transcript || '');
 
     // 3. call_summaries 저장
     const summary = await this.dbService.createCallSummary({
@@ -96,80 +59,6 @@ export class AiService {
       healthKeywords: analysis.healthKeywords,
       duration: callInfo.duration,
       createdAt: summary.analyzed_at,
-    };
-  }
-
-  private async analyzeWithOpenAI(
-    transcript: string,
-  ): Promise<CallAnalysisResult> {
-    if (!this.openai) {
-      return this.getMockAnalysis();
-    }
-
-    const systemPrompt = `당신은 어르신과 AI(다미)의 대화를 분석하는 전문가입니다.
-다음 JSON 형식으로 분석 결과를 반환해주세요:
-{
-  "summary": "대화 요약 (2-3문장, 한국어)",
-  "mood": "positive" | "neutral" | "negative",
-  "moodScore": 0.0 ~ 1.0 (감정 점수, 1이 가장 긍정적),
-  "tags": ["키워드1", "키워드2", ...] (최대 5개, 한국어),
-  "healthKeywords": {
-    "pain": 언급 횟수 (숫자) 또는 null,
-    "sleep": "good" | "bad" | "mentioned" 또는 null,
-    "meal": "regular" | "irregular" | "mentioned" 또는 null,
-    "medication": "compliant" | "non-compliant" | "mentioned" 또는 null
-  }
-}`;
-
-    try {
-      const response = await this.openai.chat.completions.create({
-        model: 'gpt-4o-mini',
-        messages: [
-          { role: 'system', content: systemPrompt },
-          { role: 'user', content: transcript || '(대화 내용 없음)' },
-        ],
-        response_format: { type: 'json_object' },
-        max_tokens: 1000,
-      });
-
-      const content = response.choices[0]?.message?.content;
-      if (!content) {
-        this.logger.warn('OpenAI returned empty response, using mock data');
-        return this.getMockAnalysis();
-      }
-
-      const result = JSON.parse(content) as CallAnalysisResult;
-      return {
-        summary: result.summary || '',
-        mood: result.mood || 'neutral',
-        moodScore: Math.max(0, Math.min(1, result.moodScore || 0.5)),
-        tags: Array.isArray(result.tags) ? result.tags.slice(0, 5) : [],
-        healthKeywords: {
-          pain: result.healthKeywords?.pain ?? null,
-          sleep: result.healthKeywords?.sleep ?? null,
-          meal: result.healthKeywords?.meal ?? null,
-          medication: result.healthKeywords?.medication ?? null,
-        },
-      };
-    } catch (error) {
-      this.logger.error(`OpenAI analysis failed: ${(error as Error).message}`);
-      return this.getMockAnalysis();
-    }
-  }
-
-  private getMockAnalysis(): CallAnalysisResult {
-    return {
-      summary:
-        '어르신께서 오늘 날씨가 좋다고 말씀하시며 즐거워하셨습니다. 손주들 이야기를 하시며 웃으셨고, 건강 상태는 양호해 보입니다.',
-      mood: 'positive',
-      moodScore: 0.85,
-      tags: ['날씨', '손주', '긍정적'],
-      healthKeywords: {
-        pain: null,
-        sleep: 'good',
-        meal: 'regular',
-        medication: null,
-      },
     };
   }
 

--- a/src/ai/providers/bedrock.provider.ts
+++ b/src/ai/providers/bedrock.provider.ts
@@ -1,0 +1,113 @@
+import { Logger } from '@nestjs/common';
+import {
+  BedrockRuntimeClient,
+  InvokeModelCommand,
+} from '@aws-sdk/client-bedrock-runtime';
+import { AiAnalysisProvider } from '../ai.interface';
+import { CallAnalysisResult, AiResponse } from '../types';
+
+export class BedrockProvider implements AiAnalysisProvider {
+  private readonly logger = new Logger(BedrockProvider.name);
+  private readonly client: BedrockRuntimeClient | null;
+  private readonly modelId: string;
+
+  constructor(
+    region?: string,
+    accessKeyId?: string,
+    secretAccessKey?: string,
+    modelId: string = 'anthropic.claude-3-haiku-20240307-v1:0',
+  ) {
+    this.modelId = modelId;
+    if (region && accessKeyId && secretAccessKey) {
+      this.client = new BedrockRuntimeClient({
+        region,
+        credentials: {
+          accessKeyId,
+          secretAccessKey,
+        },
+      });
+      this.logger.log('Bedrock client initialized');
+    } else {
+      this.client = null;
+      this.logger.warn('AWS credentials not set, AI analysis will fail');
+    }
+  }
+
+  async analyze(transcript: string): Promise<CallAnalysisResult> {
+    if (!this.client) {
+      return { success: false, error: 'AWS credentials are not configured' };
+    }
+
+    const systemPrompt = `당신은 어르신과 AI(다미)의 대화를 분석하는 전문가입니다.
+다음 JSON 형식으로 분석 결과를 반환해주세요:
+{
+  "summary": "대화 요약 (2-3문장, 한국어)",
+  "mood": "positive" | "neutral" | "negative",
+  "moodScore": 0.0 ~ 1.0 (감정 점수, 1이 가장 긍정적),
+  "tags": ["키워드1", "키워드2", ...] (최대 5개, 한국어),
+  "healthKeywords": {
+    "pain": 언급 횟수 (숫자) 또는 null,
+    "sleep": "good" | "bad" | "mentioned" 또는 null,
+    "meal": "regular" | "irregular" | "mentioned" 또는 null,
+    "medication": "compliant" | "non-compliant" | "mentioned" 또는 null
+  }
+}`;
+
+    const payload = {
+      anthropic_version: 'bedrock-2023-05-31',
+      max_tokens: 1000,
+      system: systemPrompt,
+      messages: [
+        {
+          role: 'user',
+          content: [
+            {
+              type: 'text',
+              text: transcript,
+            },
+          ],
+        },
+      ],
+    };
+
+    try {
+      const command = new InvokeModelCommand({
+        modelId: this.modelId,
+        contentType: 'application/json',
+        body: JSON.stringify(payload),
+      });
+
+      const response = await this.client.send(command);
+      const responseBody = JSON.parse(new TextDecoder().decode(response.body));
+
+      const content = responseBody.content?.[0]?.text;
+
+      if (!content) {
+        return { success: false, error: 'Bedrock returned empty response' };
+      }
+
+      // Extract JSON from content if it contains other text
+      const jsonMatch = content.match(/\{[\s\S]*\}/);
+      const jsonString = jsonMatch ? jsonMatch[0] : content;
+
+      const result = JSON.parse(jsonString) as AiResponse;
+
+      return {
+        success: true,
+        summary: result.summary || '',
+        mood: result.mood || 'neutral',
+        moodScore: Math.max(0, Math.min(1, result.moodScore || 0.5)),
+        tags: Array.isArray(result.tags) ? result.tags.slice(0, 5) : [],
+        healthKeywords: {
+          pain: result.healthKeywords?.pain ?? null,
+          sleep: result.healthKeywords?.sleep ?? null,
+          meal: result.healthKeywords?.meal ?? null,
+          medication: result.healthKeywords?.medication ?? null,
+        },
+      };
+    } catch (error) {
+      this.logger.error(`Bedrock analysis failed: ${(error as Error).message}`);
+      return { success: false, error: (error as Error).message };
+    }
+  }
+}

--- a/src/ai/providers/bedrock.provider.ts
+++ b/src/ai/providers/bedrock.provider.ts
@@ -81,9 +81,29 @@ export class BedrockProvider implements AiAnalysisProvider {
 
       // Extract JSON from content if it contains other text
       const jsonMatch = content.match(/\{[\s\S]*\}/);
-      const jsonString = jsonMatch ? jsonMatch[0] : content;
+      if (!jsonMatch) {
+        this.logger.error(
+          `Failed to extract JSON from Bedrock response: ${content}`,
+        );
+        return {
+          success: false,
+          error: 'Failed to extract valid JSON from response',
+        };
+      }
 
-      const result = JSON.parse(jsonString) as AiResponse;
+      let result: AiResponse;
+      try {
+        result = JSON.parse(jsonMatch[0]) as AiResponse;
+      } catch (parseError) {
+        this.logger.error(
+          `JSON parsing failed: ${(parseError as Error).message}`,
+        );
+        return {
+          success: false,
+          error: 'Invalid JSON format in response',
+        };
+      }
+
 
       return {
         success: true,

--- a/src/ai/providers/openai.provider.ts
+++ b/src/ai/providers/openai.provider.ts
@@ -3,13 +3,24 @@ import OpenAI from 'openai';
 import { AiAnalysisProvider } from '../ai.interface';
 import { CallAnalysisResult, AiResponse } from '../types';
 
+import { DEFAULT_SYSTEM_PROMPT } from '../ai.constants';
+
 export class OpenAiProvider implements AiAnalysisProvider {
   private readonly logger = new Logger(OpenAiProvider.name);
   private readonly openai: OpenAI | null;
   private readonly model: string;
+  private readonly maxTokens: number;
+  private readonly systemPrompt: string;
 
-  constructor(apiKey?: string, model: string = 'gpt-4o-mini') {
+  constructor(
+    apiKey?: string,
+    model: string = 'gpt-4o-mini',
+    maxTokens: number = 1000,
+    systemPrompt: string = DEFAULT_SYSTEM_PROMPT,
+  ) {
     this.model = model;
+    this.maxTokens = maxTokens;
+    this.systemPrompt = systemPrompt;
     if (apiKey) {
       this.openai = new OpenAI({ apiKey });
       this.logger.log('OpenAI client initialized');
@@ -24,30 +35,15 @@ export class OpenAiProvider implements AiAnalysisProvider {
       return { success: false, error: 'OpenAI API key is not configured' };
     }
 
-    const systemPrompt = `당신은 어르신과 AI(다미)의 대화를 분석하는 전문가입니다.
-다음 JSON 형식으로 분석 결과를 반환해주세요:
-{
-  "summary": "대화 요약 (2-3문장, 한국어)",
-  "mood": "positive" | "neutral" | "negative",
-  "moodScore": 0.0 ~ 1.0 (감정 점수, 1이 가장 긍정적),
-  "tags": ["키워드1", "키워드2", ...] (최대 5개, 한국어),
-  "healthKeywords": {
-    "pain": 언급 횟수 (숫자) 또는 null,
-    "sleep": "good" | "bad" | "mentioned" 또는 null,
-    "meal": "regular" | "irregular" | "mentioned" 또는 null,
-    "medication": "compliant" | "non-compliant" | "mentioned" 또는 null
-  }
-}`;
-
     try {
       const response = await this.openai.chat.completions.create({
         model: this.model,
         messages: [
-          { role: 'system', content: systemPrompt },
+          { role: 'system', content: this.systemPrompt },
           { role: 'user', content: transcript },
         ],
         response_format: { type: 'json_object' },
-        max_tokens: 1000,
+        max_tokens: this.maxTokens,
       });
 
       const content = response.choices[0]?.message?.content;

--- a/src/ai/providers/openai.provider.ts
+++ b/src/ai/providers/openai.provider.ts
@@ -1,0 +1,93 @@
+import { Logger } from '@nestjs/common';
+import OpenAI from 'openai';
+import { AiAnalysisProvider } from '../ai.interface';
+import { CallAnalysisResult } from '../types';
+
+export class OpenAiProvider implements AiAnalysisProvider {
+  private readonly logger = new Logger(OpenAiProvider.name);
+  private readonly openai: OpenAI | null;
+
+  constructor(apiKey?: string) {
+    if (apiKey) {
+      this.openai = new OpenAI({ apiKey });
+      this.logger.log('OpenAI client initialized');
+    } else {
+      this.openai = null;
+      this.logger.warn(
+        'OPENAI_API_KEY not set, AI analysis will use mock data',
+      );
+    }
+  }
+
+  async analyze(transcript: string): Promise<CallAnalysisResult> {
+    if (!this.openai) {
+      return this.getMockAnalysis();
+    }
+
+    const systemPrompt = `당신은 어르신과 AI(다미)의 대화를 분석하는 전문가입니다.
+다음 JSON 형식으로 분석 결과를 반환해주세요:
+{
+  "summary": "대화 요약 (2-3문장, 한국어)",
+  "mood": "positive" | "neutral" | "negative",
+  "moodScore": 0.0 ~ 1.0 (감정 점수, 1이 가장 긍정적),
+  "tags": ["키워드1", "키워드2", ...] (최대 5개, 한국어),
+  "healthKeywords": {
+    "pain": 언급 횟수 (숫자) 또는 null,
+    "sleep": "good" | "bad" | "mentioned" 또는 null,
+    "meal": "regular" | "irregular" | "mentioned" 또는 null,
+    "medication": "compliant" | "non-compliant" | "mentioned" 또는 null
+  }
+}`;
+
+    try {
+      const response = await this.openai.chat.completions.create({
+        model: 'gpt-4o-mini',
+        messages: [
+          { role: 'system', content: systemPrompt },
+          { role: 'user', content: transcript || '(대화 내용 없음)' },
+        ],
+        response_format: { type: 'json_object' },
+        max_tokens: 1000,
+      });
+
+      const content = response.choices[0]?.message?.content;
+      if (!content) {
+        this.logger.warn('OpenAI returned empty response, using mock data');
+        return this.getMockAnalysis();
+      }
+
+      const result = JSON.parse(content) as CallAnalysisResult;
+      return {
+        summary: result.summary || '',
+        mood: result.mood || 'neutral',
+        moodScore: Math.max(0, Math.min(1, result.moodScore || 0.5)),
+        tags: Array.isArray(result.tags) ? result.tags.slice(0, 5) : [],
+        healthKeywords: {
+          pain: result.healthKeywords?.pain ?? null,
+          sleep: result.healthKeywords?.sleep ?? null,
+          meal: result.healthKeywords?.meal ?? null,
+          medication: result.healthKeywords?.medication ?? null,
+        },
+      };
+    } catch (error) {
+      this.logger.error(`OpenAI analysis failed: ${(error as Error).message}`);
+      return this.getMockAnalysis();
+    }
+  }
+
+  private getMockAnalysis(): CallAnalysisResult {
+    return {
+      summary:
+        '어르신께서 오늘 날씨가 좋다고 말씀하시며 즐거워하셨습니다. 손주들 이야기를 하시며 웃으셨고, 건강 상태는 양호해 보입니다.',
+      mood: 'positive',
+      moodScore: 0.85,
+      tags: ['날씨', '손주', '긍정적'],
+      healthKeywords: {
+        pain: null,
+        sleep: 'good',
+        meal: 'regular',
+        medication: null,
+      },
+    };
+  }
+}

--- a/src/ai/providers/openai.provider.ts
+++ b/src/ai/providers/openai.provider.ts
@@ -6,8 +6,10 @@ import { CallAnalysisResult, AiResponse } from '../types';
 export class OpenAiProvider implements AiAnalysisProvider {
   private readonly logger = new Logger(OpenAiProvider.name);
   private readonly openai: OpenAI | null;
+  private readonly model: string;
 
-  constructor(apiKey?: string) {
+  constructor(apiKey?: string, model: string = 'gpt-4o-mini') {
+    this.model = model;
     if (apiKey) {
       this.openai = new OpenAI({ apiKey });
       this.logger.log('OpenAI client initialized');
@@ -39,7 +41,7 @@ export class OpenAiProvider implements AiAnalysisProvider {
 
     try {
       const response = await this.openai.chat.completions.create({
-        model: 'gpt-4o-mini',
+        model: this.model,
         messages: [
           { role: 'system', content: systemPrompt },
           { role: 'user', content: transcript || '(대화 내용 없음)' },

--- a/src/ai/providers/openai.provider.ts
+++ b/src/ai/providers/openai.provider.ts
@@ -44,7 +44,7 @@ export class OpenAiProvider implements AiAnalysisProvider {
         model: this.model,
         messages: [
           { role: 'system', content: systemPrompt },
-          { role: 'user', content: transcript || '(대화 내용 없음)' },
+          { role: 'user', content: transcript },
         ],
         response_format: { type: 'json_object' },
         max_tokens: 1000,

--- a/src/ai/types.ts
+++ b/src/ai/types.ts
@@ -1,0 +1,24 @@
+export type CallAnalysisResult = {
+  summary: string;
+  mood: 'positive' | 'neutral' | 'negative';
+  moodScore: number;
+  tags: string[];
+  healthKeywords: {
+    pain: number | null;
+    sleep: string | null;
+    meal: string | null;
+    medication: string | null;
+  };
+};
+
+export type AnalyzeCallResult = {
+  callId: string;
+  wardId: string | null;
+  summary: string;
+  mood: string;
+  moodScore: number;
+  tags: string[];
+  healthKeywords: Record<string, unknown>;
+  duration: number | null;
+  createdAt: string;
+};

--- a/src/ai/types.ts
+++ b/src/ai/types.ts
@@ -1,4 +1,4 @@
-export type CallAnalysisResult = {
+export type AiResponse = {
   summary: string;
   mood: 'positive' | 'neutral' | 'negative';
   moodScore: number;
@@ -11,14 +11,20 @@ export type CallAnalysisResult = {
   };
 };
 
-export type AnalyzeCallResult = {
-  callId: string;
-  wardId: string | null;
-  summary: string;
-  mood: string;
-  moodScore: number;
-  tags: string[];
-  healthKeywords: Record<string, unknown>;
-  duration: number | null;
-  createdAt: string;
-};
+export type CallAnalysisResult =
+  | ({ success: true } & AiResponse)
+  | { success: false; error: string };
+
+export type AnalyzeCallResult =
+  | ({ success: true } & AiResponse & {
+      callId: string;
+      wardId: string | null;
+      duration: number | null;
+      createdAt: string;
+    })
+  | {
+      success: false;
+      callId: string;
+      error: string;
+    };
+

--- a/src/ai/types.ts
+++ b/src/ai/types.ts
@@ -11,20 +11,29 @@ export type AiResponse = {
   };
 };
 
-export type CallAnalysisResult =
-  | ({ success: true } & AiResponse)
-  | { success: false; error: string };
+export type CallAnalysisSuccess = AiResponse & {
+  success: true;
+};
 
-export type AnalyzeCallResult =
-  | ({ success: true } & AiResponse & {
-      callId: string;
-      wardId: string | null;
-      duration: number | null;
-      createdAt: string;
-    })
-  | {
-      success: false;
-      callId: string;
-      error: string;
-    };
+export type CallAnalysisFailure = {
+  success: false;
+  error: string;
+};
 
+export type CallAnalysisResult = CallAnalysisSuccess | CallAnalysisFailure;
+
+export type AnalyzeCallSuccess = AiResponse & {
+  success: true;
+  callId: string;
+  wardId: string | null;
+  duration: number | null;
+  createdAt: string;
+};
+
+export type AnalyzeCallFailure = {
+  success: false;
+  callId: string;
+  error: string;
+};
+
+export type AnalyzeCallResult = AnalyzeCallSuccess | AnalyzeCallFailure;


### PR DESCRIPTION
- **refactor: LLM provider를 의존성으로 주입받는 형태로 개선**
- **refactor: 실패시 mock데이터 반환 대신 요청 실패를 반환**
- **refactor: 대화기록이 없을 경우 AI 분석을 수행하지 않고 즉시 실패 응답을 반환**
- **feat: 추가(AWS bedrock provider)**
- **sq to 08a6e4a**
- **refactor: max_token, 프롬프트를 환경변수로 주입하는 방식으로 개선**
- **refactor: 문자열을 이용한 의존성 주입 대신 추상화 클래스 생성**

---

> [!CAUTION]
>
> - 이 PR의 기능은 [ops-infra 레포지토리의 이 PR](https://github.com/Namanmoo-Damso/ops-infra/pull/5)도 함께 반영되어야 동작합니다.
> - ops-infra 레포지토리의 변경내역을 확인하고, api.env 파일에 값을 추가하세요.


> [!WARNING]
>
> - ai 통화 기능의 완성 이후 테스트 할 수 있습니다.


## 무엇이 변경되었나요

#### 1. 구조 및 로직 개선

*   **Mock 데이터 제거**: API 호출 실패 시 임의의 Mock 데이터를 반환하던 로직을 제거하고, 실제 실패 여부를 반환하도록 수정했습니다.
*   **에러 핸들링 강화**: `CallAnalysisResult` 타입을 `success/failure` 패턴(Discriminated Union)으로 변경하여, 서비스 계층에서 성공/실패 여부를 명시적으로 처리하도록 개선했습니다.
*   **불필요한 호출 방지**: `transcript`가 없거나 빈 문자열일 경우 AI 서비스를 호출하지 않고 즉시 종료하도록 최적화했습니다.

#### 2. 기능 확장 (Multi-Provider)

*   **Amazon Bedrock 추가**: 기존 OpenAI 외에 AWS Bedrock(Claude 3 Haiku 등)을 사용할 수 있는 `BedrockProvider`를 구현했습니다.
*   **Provider 동적 선택**: `AI_PROVIDER` 환경 변수를 통해 서비스 재배포 없이 AI 공급자를 전환할 수 있습니다.

#### 3. 설정 유연화

*   **모델 및 파라미터 설정**: `OPENAI_MODEL`, `BEDROCK_MODEL`, `AI_MAX_TOKENS` 환경 변수를 통해 모델 종류와 토큰 제한을 설정할 수 있습니다.
*   **프롬프트 분리**: JSON 응답 스키마는 고정하되, AI 페르소나 및 지시문(`AI_INSTRUCTION`)만 환경 변수로 주입할 수 있도록 구조를 개선했습니다.

#### 4. 아키텍처 개선 (DI)

*   **의존성 주입 방식 변경**: `AI_PROVIDER` 문자열 토큰 대신 `AiAnalysisProvider` 추상 클래스를 사용하여 타입 안전성을 확보하고, 향후 모듈 분리에 용이한 구조로 변경했습니다.


---
This PR closes #12 