### PR TITLE
feat(agent): Voice Agent OpenAI에서 AWS로 전환

### DIFF
--- a/agents/.env.example
+++ b/agents/.env.example
@@ -1,8 +1,10 @@
 # Environment variables for the AI agent
 # Copy to `.env` and fill values before running
 
-# OpenAI / LLM
-OPENAI_API_KEY=
+# AWS Credentials (for Transcribe, Polly, Bedrock)
+AWS_ACCESS_KEY_ID=
+AWS_SECRET_ACCESS_KEY=
+AWS_DEFAULT_REGION=ap-northeast-2
 
 # LiveKit connection (used by the LiveKit agent SDK)
 LIVEKIT_URL=ws://localhost:7880
@@ -15,6 +17,6 @@ LIVEKIT_TOKEN_TTL=600
 LOG_LEVEL=INFO
 
 # Notes:
-# - `OPENAI_API_KEY` is required for the agent's OpenAI plugin.
+# - AWS credentials are required for Amazon Transcribe (STT), Polly (TTS), and Bedrock (LLM).
 # - If running this service alongside the main project, ensure LiveKit
 #   endpoint and API keys match your LiveKit server configuration.

--- a/agents/Dockerfile
+++ b/agents/Dockerfile
@@ -14,5 +14,5 @@ COPY . .
 
 ENV PYTHONUNBUFFERED=1
 
-# Default to simple_agent.py (can override in docker-compose)
-CMD ["python", "voice/simple_agent.py"]
+# Default to simple_agent.py with start command
+CMD ["python", "voice/simple_agent.py", "start"]

--- a/agents/requirements.txt
+++ b/agents/requirements.txt
@@ -3,7 +3,7 @@ python-dotenv>=1.0.0,<2.0.0
 
 # LiveKit AI Agents framework
 livekit-agents>=0.8.0,<1.0.0
-livekit-plugins-openai>=0.6.0,<1.0.0
+livekit-plugins-aws>=1.0.0,<2.0.0
 livekit-plugins-silero>=0.6.0,<1.0.0
 
 # Note: Pin exact versions in production for reproducible builds

--- a/agents/requirements.txt
+++ b/agents/requirements.txt
@@ -2,9 +2,9 @@
 python-dotenv>=1.0.0,<2.0.0
 
 # LiveKit AI Agents framework
-livekit-agents>=0.8.0,<1.0.0
-livekit-plugins-aws>=1.0.0,<2.0.0
-livekit-plugins-silero>=0.6.0,<1.0.0
+livekit-agents>=1.0.0
+livekit-plugins-aws>=1.0.0
+livekit-plugins-silero>=1.0.0
 
 # Note: Pin exact versions in production for reproducible builds
 # To generate exact versions: pip freeze > requirements.txt

--- a/agents/voice/config.py
+++ b/agents/voice/config.py
@@ -24,7 +24,9 @@ def validate_env_vars() -> dict[str, str]:
         "LIVEKIT_URL",
         "LIVEKIT_API_KEY",
         "LIVEKIT_API_SECRET",
-        "OPENAI_API_KEY",
+        "AWS_ACCESS_KEY_ID",
+        "AWS_SECRET_ACCESS_KEY",
+        "AWS_DEFAULT_REGION",
     ]
 
     missing_vars = []
@@ -51,11 +53,11 @@ def validate_env_vars() -> dict[str, str]:
             f"LIVEKIT_URL must start with ws:// or wss://, got: {livekit_url}"
         )
 
-    # Validate API key format (basic check)
-    openai_key = config["OPENAI_API_KEY"]
-    if not openai_key.startswith("sk-"):
+    # Validate AWS credentials format (basic check)
+    aws_key = config["AWS_ACCESS_KEY_ID"]
+    if not aws_key.startswith("AKIA"):
         raise ConfigError(
-            "OPENAI_API_KEY appears invalid (should start with 'sk-')"
+            "AWS_ACCESS_KEY_ID appears invalid (should start with 'AKIA')"
         )
 
     return config

--- a/agents/voice/simple_agent.py
+++ b/agents/voice/simple_agent.py
@@ -10,7 +10,7 @@ from livekit.agents import (
 )
 
 from livekit.agents.voice import Agent, AgentSession
-from livekit.plugins import openai, silero
+from livekit.plugins import aws, silero
 import logging
 
 from config import validate_env_vars, get_optional_config, ConfigError
@@ -79,14 +79,14 @@ async def entrypoint(ctx: JobContext):
             "- Weather and seasons"
         ),
         # ✅ Configure models IN THE AGENT (not session) for proper instruction binding
-        stt=openai.STT(language="ko"),  # Korean speech-to-text
-        llm=openai.LLM(
-            model="gpt-4o-mini", #문맥 이해도가 더 높으며 3.5보다 저렴함
-            temperature=0.7,  # Slightly lower for more consistent responses
+        stt=aws.STT(language="ko-KR"),  # Amazon Transcribe - Korean
+        llm=aws.LLM(
+            model="anthropic.claude-sonnet-4-20250514-v1:0",  # Bedrock Claude Sonnet 4
+            temperature=0.7,
         ),
-        tts=openai.TTS(
-            voice="shimmer", # 차분한 여성 목소리, 아니면 echo(중후한 남성)으로 안정감, ElevenLabsTrubo v.25(손녀/손자 따듯한 목소리) 근데 더 비쌈
-            speed=0.85,  # 알아 듣기 쉽게 천천히 말하기
+        tts=aws.TTS(
+            voice="Seoyeon",  # Amazon Polly - 한국어 여성 음성
+            engine="neural",  # neural 엔진 사용 (더 자연스러운 음성)
         ),
         vad=silero.VAD.load(
             min_speech_duration=0.1,  # Detect speech faster (default 0.25s)


### PR DESCRIPTION
## 개요
Voice Agent의 AI 서비스를 OpenAI에서 AWS로 전환합니다.

## 변경 사항
- STT: OpenAI Whisper → Amazon Transcribe (ko-KR)
- LLM: GPT-4o-mini → Amazon Bedrock Claude Sonnet 4
- TTS: OpenAI TTS → Amazon Polly (Seoyeon, neural)
- `requirements.txt`에서 `livekit-plugins-openai` → `livekit-plugins-aws`
- `config.py`에서 AWS credentials 검증 로직으로 변경

## 이유
- AWS 인프라 통합
- 비용 최적화
- 서울 리전 사용으로 레이턴시 개선

closes #21