### PR TITLE
fix(auth): 이메일 매칭 대소문자 무시 및 회원탈퇴 로직 수정

### DIFF
--- a/src/database/repositories/guardian.repository.ts
+++ b/src/database/repositories/guardian.repository.ts
@@ -63,8 +63,9 @@ export class GuardianRepository {
   }
 
   async findByWardEmail(wardEmail: string): Promise<GuardianRow | undefined> {
+    const normalizedEmail = wardEmail.toLowerCase().trim();
     const guardian = await this.prisma.guardian.findFirst({
-      where: { wardEmail },
+      where: { wardEmail: { equals: normalizedEmail, mode: 'insensitive' } },
     });
     return guardian ? toGuardianRow(guardian) : undefined;
   }

--- a/src/database/repositories/user.repository.ts
+++ b/src/database/repositories/user.repository.ts
@@ -106,10 +106,23 @@ export class UserRepository {
       });
     }
 
-    // 5. Delete ward record if user is a ward
-    await this.prisma.ward.deleteMany({
+    // 5. Reset organization ward links and delete ward record if user is a ward
+    const ward = await this.prisma.ward.findFirst({
       where: { userId },
     });
+    if (ward) {
+      // Reset OrganizationWard to allow re-registration
+      await this.prisma.organizationWard.updateMany({
+        where: { wardId: ward.id },
+        data: {
+          wardId: null,
+          isRegistered: false,
+        },
+      });
+      await this.prisma.ward.delete({
+        where: { id: ward.id },
+      });
+    }
 
     // 6. Delete user
     await this.prisma.user.delete({

--- a/src/database/repositories/ward.repository.ts
+++ b/src/database/repositories/ward.repository.ts
@@ -381,11 +381,13 @@ export class WardRepository {
   /**
    * Find pending organization ward by email (across all organizations)
    * Used for auto-linking when ward signs up
+   * Case-insensitive email matching
    */
   async findPendingOrganizationWardByEmail(email: string) {
+    const normalizedEmail = email.toLowerCase().trim();
     const orgWard = await this.prisma.organizationWard.findFirst({
       where: {
-        email,
+        email: { equals: normalizedEmail, mode: 'insensitive' },
         isRegistered: false,
         wardId: null,
       },


### PR DESCRIPTION
## Summary
- org_ward 이메일로 카카오 로그인 시 매칭 실패 오류 수정
- 회원탈퇴 후 재가입 불가 오류 수정

## Changes
- `findPendingOrganizationWardByEmail`: case-insensitive 이메일 매칭
- `findByWardEmail`: case-insensitive 이메일 매칭  
- `deleteUser`: Ward 삭제 시 OrganizationWard 리셋 (isRegistered=false, wardId=null)

## Test plan
- [ ] org_ward에 등록된 이메일로 카카오 로그인 테스트
- [ ] 회원탈퇴 후 동일 이메일로 재가입 테스트