### PR TITLE
fix(rtc): 익명 사용자 자동 생성 방지

### DIFF
--- a/src/database/db.service.ts
+++ b/src/database/db.service.ts
@@ -64,6 +64,10 @@ export class DbService implements OnModuleDestroy {
     return this.users.findByKakaoId(kakaoId);
   }
 
+  async findUserByIdentity(identity: string) {
+    return this.users.findByIdentity(identity);
+  }
+
   async updateUserType(userId: string, userType: 'guardian' | 'ward') {
     return this.users.updateType(userId, userType);
   }

--- a/src/database/repositories/user.repository.ts
+++ b/src/database/repositories/user.repository.ts
@@ -40,6 +40,13 @@ export class UserRepository {
     return user ? toUserRow(user) : undefined;
   }
 
+  async findByIdentity(identity: string): Promise<UserRow | undefined> {
+    const user = await this.prisma.user.findUnique({
+      where: { identity },
+    });
+    return user ? toUserRow(user) : undefined;
+  }
+
   async updateType(
     userId: string,
     userType: 'guardian' | 'ward',

--- a/src/rtc/rtc.controller.ts
+++ b/src/rtc/rtc.controller.ts
@@ -178,6 +178,7 @@ export class RtcController {
               supportsCallKit: body.supportsCallKit,
             }
           : undefined,
+      isAuthenticated: !!authIdentity,
     });
 
     return {


### PR DESCRIPTION
## Summary
- RTC 토큰 발급 시 인증되지 않은 요청의 익명 사용자(ios-user) 자동 생성 차단
- 인증된 사용자만 upsertUser 호출, 미인증 시 findUserByIdentity로 기존 사용자만 조회
- 사용자가 없으면 "로그인이 필요합니다" 에러 반환

## Changes
- `rtc-token.service.ts`: isAuthenticated 파라미터 추가, 조건부 사용자 생성 로직
- `rtc.controller.ts`: authIdentity 유무로 isAuthenticated 전달
- `user.repository.ts`: findByIdentity 메서드 추가
- `db.service.ts`: findUserByIdentity facade 메서드 추가

## Test plan
- [ ] 로그인 후 RTC 토큰 요청 시 정상 발급 확인
- [ ] 로그인 없이 RTC 토큰 요청 시 에러 반환 확인
- [ ] 기존 users 테이블에 ios-* 레코드 더 이상 생성되지 않음 확인