### PR TITLE
fix(devices): 디바이스 등록 시 익명 사용자 생성 차단

### DIFF
--- a/src/database/db.service.ts
+++ b/src/database/db.service.ts
@@ -118,7 +118,11 @@ export class DbService implements OnModuleDestroy {
     voipToken?: string;
     supportsCallKit?: boolean;
   }) {
-    const user = await this.upsertUser(params.identity, params.displayName);
+    // 익명 사용자 생성 차단 - 기존 사용자만 허용
+    const user = await this.findUserByIdentity(params.identity);
+    if (!user) {
+      throw new Error('로그인이 필요합니다');
+    }
     return this.devices.upsert(user, params);
   }
 


### PR DESCRIPTION
## Summary
- 디바이스 등록 API에서도 익명 사용자(ios-user) 자동 생성 차단
- PR #38과 함께 익명 사용자 생성 완전 차단

## Changes
- `db.service.ts`: upsertDevice에서 upsertUser → findUserByIdentity 변경
- 기존 사용자가 없으면 "로그인이 필요합니다" 에러 반환

## 관련 PR
- #38: RTC 토큰 발급 시 익명 사용자 생성 차단

## 영향
- iOS 앱에서 카카오 로그인 후에만 디바이스 등록 가능
- 로그인 전 디바이스 등록 시도 시 에러 반환