### PR TITLE
[refactor] iOS 유저 퇴장 시 방 자동 삭제 로직 추가

### DIFF
--- a/src/integration/livekit/livekit.service.ts
+++ b/src/integration/livekit/livekit.service.ts
@@ -131,7 +131,9 @@ export class LiveKitService {
   }
 
   /**
-   * Close rooms that only have admin participants
+   * Close rooms that only have admin and/or agent participants
+   * (i.e., no real users like kakao_ or google_ users remain)
+   * Also deletes empty rooms
    */
   async closeAdminOnlyRooms(): Promise<void> {
     try {
@@ -140,15 +142,33 @@ export class LiveKitService {
       for (const room of rooms) {
         const participants = await this.roomService.listParticipants(room.name);
 
-        // Check if all participants are admins
-        const hasOnlyAdmins =
-          participants.length > 0 &&
-          participants.every(p => p.identity.startsWith('admin_'));
+        // Delete empty rooms
+        if (participants.length === 0) {
+          this.logger.log(`Deleting empty room: ${room.name}`);
+          try {
+            await this.roomService.deleteRoom(room.name);
+          } catch (err) {
+            this.logger.debug(
+              `Failed to delete empty room ${room.name}: ${(err as Error).message}`,
+            );
+          }
+          continue;
+        }
 
-        if (hasOnlyAdmins) {
-          this.logger.log(`Closing admin-only room: ${room.name}`);
+        // Check if there are any real users (not admin or agent)
+        const hasRealUsers = participants.some(
+          p =>
+            !p.identity.startsWith('admin_') &&
+            !p.identity.startsWith('agent-'),
+        );
 
-          // Remove all admin participants to close the room
+        // If no real users remain (only admin and/or agent), close the room
+        if (!hasRealUsers) {
+          this.logger.log(
+            `Closing room with only admin/agent participants: ${room.name}`,
+          );
+
+          // Remove all participants first, then delete the room
           for (const participant of participants) {
             try {
               await this.roomService.removeParticipant(
@@ -160,6 +180,16 @@ export class LiveKitService {
                 `Failed to remove participant ${participant.identity} from ${room.name}: ${(err as Error).message}`,
               );
             }
+          }
+
+          // Delete the room after removing participants
+          try {
+            await this.roomService.deleteRoom(room.name);
+            this.logger.log(`Deleted room: ${room.name}`);
+          } catch (err) {
+            this.logger.debug(
+              `Failed to delete room ${room.name}: ${(err as Error).message}`,
+            );
           }
         }
       }


### PR DESCRIPTION
[refactor] iOS 유저 퇴장 시 방 자동 삭제 로직 추가 (#30)

📋 현재 문제
- 방 삭제 불완전: Agent + Host가 방에 남아 있으면 방이 자동으로 삭제되지 않음 (좀비 방 발생)
- iOS 탈출 미흡: 사용자가 나가도 Agent/Host가 남아 있어 방이 유지됨

🔧 개선 방안
Phase 1: 백엔드 API 개선
- 명시적 방 정리 엔드포인트 추가: 모든 참가자(Agent, Host)를 강제 퇴장 후 방 완전 삭제
- 사용자 퇴장 시 역할 기반 처리:
  - Host 유저 퇴장 시 전체 방 정리
  - iOS 유저 퇴장 시 남은 참가자 확인 후 방 정리
  
  Closes #30 