### PR TITLE
[feat] 수혜자 상세 정보 관리 고도화 및 CRUD 구현

### DIFF
--- a/prisma/migrations/20260201090000_add_organization_ward_details/migration.sql
+++ b/prisma/migrations/20260201090000_add_organization_ward_details/migration.sql
@@ -1,0 +1,38 @@
+-- Create organization_ward_details table for detailed beneficiary info.
+CREATE TABLE IF NOT EXISTS organization_ward_details (
+  organization_ward_id uuid PRIMARY KEY,
+  guardian text,
+  diseases text[] NOT NULL DEFAULT ARRAY[]::text[],
+  medication text,
+  notes text,
+  created_at timestamptz NOT NULL DEFAULT now(),
+  updated_at timestamptz NOT NULL DEFAULT now(),
+  CONSTRAINT organization_ward_details_organization_ward_id_fkey
+    FOREIGN KEY (organization_ward_id)
+    REFERENCES organization_wards(id)
+    ON DELETE CASCADE
+);
+
+-- Backfill existing detail fields from organization_wards.
+INSERT INTO organization_ward_details (
+  organization_ward_id,
+  diseases,
+  medication,
+  notes,
+  created_at,
+  updated_at
+)
+SELECT
+  id,
+  COALESCE(diseases, ARRAY[]::text[]),
+  medication,
+  notes,
+  now(),
+  now()
+FROM organization_wards
+ON CONFLICT (organization_ward_id) DO NOTHING;
+
+-- Drop duplicated detail columns from organization_wards.
+ALTER TABLE organization_wards DROP COLUMN IF EXISTS diseases;
+ALTER TABLE organization_wards DROP COLUMN IF EXISTS medication;
+ALTER TABLE organization_wards DROP COLUMN IF EXISTS notes;

--- a/prisma/migrations/20260201090000_add_organization_ward_details/migration.sql
+++ b/prisma/migrations/20260201090000_add_organization_ward_details/migration.sql
@@ -27,8 +27,8 @@ SELECT
   COALESCE(diseases, ARRAY[]::text[]),
   medication,
   notes,
-  now(),
-  now()
+  created_at,
+  updated_at
 FROM organization_wards
 ON CONFLICT (organization_ward_id) DO NOTHING;
 

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -335,7 +335,8 @@ model OrganizationWard {
   name              String
   birthDate         DateTime? @map("birth_date") @db.Date
   address           String?
-  notes             String?
+  gender            String?
+  wardType          String?   @map("ward_type")
   isRegistered      Boolean   @default(false) @map("is_registered")
   wardId            String?   @map("ward_id") @db.Uuid
   createdAt         DateTime  @default(now()) @map("created_at")
@@ -345,6 +346,7 @@ model OrganizationWard {
   organization    Organization @relation(fields: [organizationId], references: [id], onDelete: Cascade)
   uploadedByAdmin Admin?       @relation(fields: [uploadedByAdminId], references: [id], onDelete: SetNull)
   ward            Ward?        @relation(fields: [wardId], references: [id], onDelete: SetNull)
+  detail          OrganizationWardDetail?
 
   @@unique([organizationId, email])
   @@index([organizationId])
@@ -357,6 +359,20 @@ model OrganizationWard {
   @@index([email(ops: raw("gin_trgm_ops"))], type: Gin, map: "organization_wards_email_trgm_idx")
   @@index([phoneNumber(ops: raw("gin_trgm_ops"))], type: Gin, map: "organization_wards_phone_trgm_idx")
   @@map("organization_wards")
+}
+
+model OrganizationWardDetail {
+  organizationWardId String   @id @map("organization_ward_id") @db.Uuid
+  guardian           String?
+  diseases           String[] @default([])
+  medication         String?
+  notes              String?
+  createdAt          DateTime @default(now()) @map("created_at")
+  updatedAt          DateTime @default(now()) @updatedAt @map("updated_at")
+
+  organizationWard OrganizationWard @relation(fields: [organizationWardId], references: [id], onDelete: Cascade)
+
+  @@map("organization_ward_details")
 }
 
 // =============================================================================

--- a/src/admin/beneficiaries/beneficiaries.controller.ts
+++ b/src/admin/beneficiaries/beneficiaries.controller.ts
@@ -1,4 +1,5 @@
 import {
+  Body,
   Controller,
   Delete,
   Get,
@@ -6,12 +7,22 @@ import {
   HttpStatus,
   Param,
   ParseUUIDPipe,
+  Put,
   Query,
   UseGuards,
   UsePipes,
   ValidationPipe,
 } from '@nestjs/common';
-import { IsBoolean, IsInt, IsOptional, IsString, Max, Min } from 'class-validator';
+import {
+  IsArray,
+  IsBoolean,
+  IsDateString,
+  IsInt,
+  IsOptional,
+  IsString,
+  Max,
+  Min,
+} from 'class-validator';
 import { Transform, Type } from 'class-transformer';
 import { DbService } from '../../database';
 import { AdminOrganizationGuard, CurrentAdmin } from '../../common';
@@ -41,6 +52,58 @@ class ListBeneficiariesQueryDto {
   pageSize: number = 10;
 }
 
+class UpdateBeneficiaryDto {
+  @IsOptional()
+  @Transform(({ value }) => (value === '' ? null : value))
+  @IsString()
+  name?: string | null;
+
+  @IsOptional()
+  @Transform(({ value }) => (value === '' ? null : value))
+  @IsString()
+  phoneNumber?: string | null;
+
+  @IsOptional()
+  @Transform(({ value }) => (value === '' ? null : value))
+  @IsDateString()
+  birthDate?: string | null;
+
+  @IsOptional()
+  @Transform(({ value }) => (value === '' ? null : value))
+  @IsString()
+  address?: string | null;
+
+  @IsOptional()
+  @Transform(({ value }) => (value === '' ? null : value))
+  @IsString()
+  gender?: string | null;
+
+  @IsOptional()
+  @Transform(({ value }) => (value === '' ? null : value))
+  @IsString()
+  wardType?: string | null;
+
+  @IsOptional()
+  @Transform(({ value }) => (value === '' ? null : value))
+  @IsString()
+  guardian?: string | null;
+
+  @IsOptional()
+  @IsArray()
+  @IsString({ each: true })
+  diseases?: string[];
+
+  @IsOptional()
+  @Transform(({ value }) => (value === '' ? null : value))
+  @IsString()
+  medication?: string | null;
+
+  @IsOptional()
+  @Transform(({ value }) => (value === '' ? null : value))
+  @IsString()
+  notes?: string | null;
+}
+
 interface BeneficiaryListResponse {
   data: BeneficiaryListItem[];
   page: number;
@@ -51,7 +114,13 @@ interface BeneficiaryListResponse {
 interface BeneficiaryDetailResponse {
   data: {
     id: string;
+    name: string;
+    email: string;
     phoneNumber: string | null;
+    birthDate: string | null;
+    address: string | null;
+    gender: string | null;
+    type: string | null;
     guardian: string | null;
     diseases: string[];
     medication: string | null;
@@ -138,6 +207,38 @@ export class BeneficiariesController {
     }
 
     return { success: true, message: '대상자 정보가 삭제되었습니다.' };
+  }
+
+  @Put(':id')
+  async update(
+    @CurrentAdmin() admin: { organization_id?: string },
+    @Param('id', new ParseUUIDPipe()) id: string,
+    @Body() body: UpdateBeneficiaryDto,
+  ): Promise<BeneficiaryDetailResponse> {
+    const organizationId = this.getOrganizationId(admin);
+
+    const updated = await this.dbService.updateOrganizationBeneficiary({
+      organizationId,
+      beneficiaryId: id,
+      data: {
+        name: body.name,
+        phoneNumber: body.phoneNumber,
+        birthDate: body.birthDate,
+        address: body.address,
+        gender: body.gender,
+        wardType: body.wardType,
+        guardian: body.guardian,
+        diseases: body.diseases,
+        medication: body.medication,
+        notes: body.notes,
+      },
+    });
+
+    if (!updated) {
+      throw new HttpException('대상자 정보를 찾을 수 없습니다.', HttpStatus.NOT_FOUND);
+    }
+
+    return { data: updated };
   }
 
   private getOrganizationId(admin: { organization_id?: string }): string {

--- a/src/admin/beneficiaries/beneficiaries.controller.ts
+++ b/src/admin/beneficiaries/beneficiaries.controller.ts
@@ -23,9 +23,14 @@ import {
   Max,
   Min,
 } from 'class-validator';
-import { Transform, Type } from 'class-transformer';
+import { Type } from 'class-transformer';
 import { DbService } from '../../database';
-import { AdminOrganizationGuard, CurrentAdmin } from '../../common';
+import {
+  AdminOrganizationGuard,
+  CurrentAdmin,
+  TransformEmptyToNull,
+  TransformEmptyToUndefined,
+} from '../../common';
 import type { BeneficiaryListItem } from '../../database/repositories/ward.repository';
 
 class ListBeneficiariesQueryDto {
@@ -54,39 +59,37 @@ class ListBeneficiariesQueryDto {
 
 class UpdateBeneficiaryDto {
   @IsOptional()
-  @Transform(({ value }) =>
-    value === '' || value === null ? undefined : value,
-  )
+  @TransformEmptyToUndefined()
   @IsString()
   name?: string;
 
   @IsOptional()
-  @Transform(({ value }) => (value === '' ? null : value))
+  @TransformEmptyToNull()
   @IsString()
   phoneNumber?: string | null;
 
   @IsOptional()
-  @Transform(({ value }) => (value === '' ? null : value))
+  @TransformEmptyToNull()
   @IsDateString()
   birthDate?: string | null;
 
   @IsOptional()
-  @Transform(({ value }) => (value === '' ? null : value))
+  @TransformEmptyToNull()
   @IsString()
   address?: string | null;
 
   @IsOptional()
-  @Transform(({ value }) => (value === '' ? null : value))
+  @TransformEmptyToNull()
   @IsString()
   gender?: string | null;
 
   @IsOptional()
-  @Transform(({ value }) => (value === '' ? null : value))
+  @TransformEmptyToNull()
   @IsString()
   wardType?: string | null;
 
   @IsOptional()
-  @Transform(({ value }) => (value === '' ? null : value))
+  @TransformEmptyToNull()
   @IsString()
   guardian?: string | null;
 
@@ -96,12 +99,12 @@ class UpdateBeneficiaryDto {
   diseases?: string[];
 
   @IsOptional()
-  @Transform(({ value }) => (value === '' ? null : value))
+  @TransformEmptyToNull()
   @IsString()
   medication?: string | null;
 
   @IsOptional()
-  @Transform(({ value }) => (value === '' ? null : value))
+  @TransformEmptyToNull()
   @IsString()
   notes?: string | null;
 }

--- a/src/admin/beneficiaries/beneficiaries.controller.ts
+++ b/src/admin/beneficiaries/beneficiaries.controller.ts
@@ -54,9 +54,11 @@ class ListBeneficiariesQueryDto {
 
 class UpdateBeneficiaryDto {
   @IsOptional()
-  @Transform(({ value }) => (value === '' ? null : value))
+  @Transform(({ value }) =>
+    value === '' || value === null ? undefined : value,
+  )
   @IsString()
-  name?: string | null;
+  name?: string;
 
   @IsOptional()
   @Transform(({ value }) => (value === '' ? null : value))

--- a/src/common/decorators/transform-empty.decorator.ts
+++ b/src/common/decorators/transform-empty.decorator.ts
@@ -1,0 +1,9 @@
+import { Transform } from 'class-transformer';
+
+export const TransformEmptyToNull = () =>
+  Transform(({ value }) => (value === '' ? null : value));
+
+export const TransformEmptyToUndefined = () =>
+  Transform(({ value }) =>
+    value === '' || value === null ? undefined : value,
+  );

--- a/src/common/index.ts
+++ b/src/common/index.ts
@@ -7,6 +7,10 @@ export type {
   CurrentUserPayload,
   CurrentAdminPayload,
 } from './decorators/current-user.decorator';
+export {
+  TransformEmptyToNull,
+  TransformEmptyToUndefined,
+} from './decorators/transform-empty.decorator';
 
 // Guards
 export { JwtAuthGuard } from './guards/jwt-auth.guard';

--- a/src/database/db.service.ts
+++ b/src/database/db.service.ts
@@ -18,7 +18,10 @@ import {
   LocationRepository,
   DashboardRepository,
 } from './repositories';
-import type { BeneficiaryListResult } from './repositories/ward.repository';
+import type {
+  BeneficiaryDetailItem,
+  BeneficiaryListResult,
+} from './repositories/ward.repository';
 
 // Re-export types for backward compatibility
 export type {
@@ -467,6 +470,13 @@ export class DbService implements OnModuleDestroy {
     pageSize: number;
   }): Promise<BeneficiaryListResult> {
     return this.wards.listOrganizationBeneficiaries(params);
+  }
+
+  async getOrganizationBeneficiaryDetail(params: {
+    organizationId: string;
+    beneficiaryId: string;
+  }): Promise<BeneficiaryDetailItem | null> {
+    return this.wards.getOrganizationBeneficiaryDetail(params);
   }
 
   // ============================================================

--- a/src/database/db.service.ts
+++ b/src/database/db.service.ts
@@ -472,6 +472,20 @@ export class DbService implements OnModuleDestroy {
     return this.wards.listOrganizationBeneficiaries(params);
   }
 
+  async deleteOrganizationBeneficiary(params: {
+    organizationId: string;
+    beneficiaryId: string;
+  }): Promise<boolean> {
+    const info = await this.wards.findOrganizationBeneficiaryForDeletion(params);
+    if (!info) return false;
+
+    if (info.ward_user_id) {
+      await this.deleteUser(info.ward_user_id);
+    }
+
+    return this.wards.deleteOrganizationBeneficiary(params);
+  }
+
   async getOrganizationBeneficiaryDetail(params: {
     organizationId: string;
     beneficiaryId: string;

--- a/src/database/db.service.ts
+++ b/src/database/db.service.ts
@@ -486,6 +486,25 @@ export class DbService implements OnModuleDestroy {
     return this.wards.deleteOrganizationBeneficiary(params);
   }
 
+  async updateOrganizationBeneficiary(params: {
+    organizationId: string;
+    beneficiaryId: string;
+    data: {
+      name?: string | null;
+      phoneNumber?: string | null;
+      birthDate?: string | null;
+      address?: string | null;
+      gender?: string | null;
+      wardType?: string | null;
+      guardian?: string | null;
+      diseases?: string[];
+      medication?: string | null;
+      notes?: string | null;
+    };
+  }): Promise<BeneficiaryDetailItem | null> {
+    return this.wards.updateOrganizationBeneficiary(params);
+  }
+
   async getOrganizationBeneficiaryDetail(params: {
     organizationId: string;
     beneficiaryId: string;

--- a/src/database/repositories/ward.repository.ts
+++ b/src/database/repositories/ward.repository.ts
@@ -538,7 +538,7 @@ export class WardRepository {
         },
       },
       include: {
-        detail: true,
+        detail: { select: { notes: true } },
       },
     });
 
@@ -563,7 +563,7 @@ export class WardRepository {
       where: { organizationId },
       orderBy: { createdAt: 'desc' },
       include: {
-        detail: true,
+        detail: { select: { notes: true } },
       },
     });
 
@@ -596,7 +596,7 @@ export class WardRepository {
             },
           },
         },
-        detail: true,
+        detail: { select: { notes: true } },
       },
       orderBy: { createdAt: 'desc' },
     });
@@ -1022,11 +1022,11 @@ function toBeneficiaryDetailItem(
 function calculateAge(birthDate: Date | null): number | null {
   if (!birthDate) return null;
   const today = new Date();
-  let age = today.getFullYear() - birthDate.getFullYear();
-  const monthDiff = today.getMonth() - birthDate.getMonth();
+  let age = today.getUTCFullYear() - birthDate.getUTCFullYear();
+  const monthDiff = today.getUTCMonth() - birthDate.getUTCMonth();
   if (
     monthDiff < 0 ||
-    (monthDiff === 0 && today.getDate() < birthDate.getDate())
+    (monthDiff === 0 && today.getUTCDate() < birthDate.getUTCDate())
   ) {
     age -= 1;
   }

--- a/src/database/repositories/ward.repository.ts
+++ b/src/database/repositories/ward.repository.ts
@@ -61,7 +61,7 @@ export interface BeneficiaryDeleteInfo {
 }
 
 export interface BeneficiaryUpdateInput {
-  name?: string | null;
+  name?: string;
   phoneNumber?: string | null;
   birthDate?: string | null;
   address?: string | null;
@@ -846,6 +846,7 @@ export class WardRepository {
       where: {
         id: params.beneficiaryId,
         organizationId: params.organizationId,
+        isRegistered: true,
       },
       select: {
         id: true,
@@ -869,6 +870,7 @@ export class WardRepository {
       where: {
         id: params.beneficiaryId,
         organizationId: params.organizationId,
+        isRegistered: true,
       },
     });
     return result.count > 0;
@@ -883,15 +885,19 @@ export class WardRepository {
       where: {
         id: params.beneficiaryId,
         organizationId: params.organizationId,
+        isRegistered: true,
       },
     });
     if (!existing) return null;
 
     const updateData: Prisma.OrganizationWardUpdateInput = {};
-    if (params.data.name !== undefined && params.data.name !== null) {
+    if (params.data.name !== undefined) {
       updateData.name = params.data.name;
     }
-    if (params.data.phoneNumber !== undefined && params.data.phoneNumber !== null) {
+    if (
+      params.data.phoneNumber !== undefined &&
+      params.data.phoneNumber !== null
+    ) {
       updateData.phoneNumber = params.data.phoneNumber;
     }
     if (params.data.birthDate !== undefined) {


### PR DESCRIPTION
📋 변경 사항

수혜자 데이터 모델 구조 개선 및 리팩토링 (Prisma)

OrganizationWard 모델에서 상세 정보를 OrganizationWardDetail로 분리 (1:1 관계)

gender, wardType, diseases(text[]), medication 등 상세 필드 확장 및 스키마 정의

기존 데이터를 신규 상세 테이블로 이전하는 백필(Backfill) 마이그레이션 적용 및 레거시 컬럼 제거

수혜자 상세 조회 및 수정 API 구현

GET /v1/admin/beneficiaries/:id 상세 응답 타입 및 조인 로직 구현

나이 계산, 감정 매핑 등 데이터 가공을 위한 헬퍼 함수 및 Repository 로직 추가

PUT /v1/admin/beneficiaries/:id 및 UpdateBeneficiaryDto 구현 (빈 문자열 null 변환 및 유효성 검증 적용)

수혜자 삭제 API 및 데이터 정합성 강화

DELETE /v1/admin/beneficiaries/:id 엔드포인트 구현

삭제 시 연관된 ward user 및 통화 요약 등 파생 데이터를 순차적으로 삭제하는 오케스트레이션 로직 적용

조직 ID 검증 공통화 및 상황별 예외 처리(404, 400) 강화

코드 리팩토링 및 유지보수성 향상

beneficiaryDetailInclude 상수화 및 toBeneficiaryDetailItem 함수 도입으로 조회/수정 응답 로직 통일

상세 응답 필드(이름, 이메일, 생년월일, 주소 등) 대폭 확장

🔗 관련 이슈

Closes #23 