### PR TITLE
feat(auth): 로그인 에러 처리 개선 및 어르신 정보 동기화

### DIFF
--- a/src/database/db.service.ts
+++ b/src/database/db.service.ts
@@ -73,6 +73,10 @@ export class DbService implements OnModuleDestroy {
     return this.users.findByIdentity(identity);
   }
 
+  async findUserByEmail(email: string) {
+    return this.users.findByEmail(email);
+  }
+
   async updateUserType(userId: string, userType: 'guardian' | 'ward') {
     return this.users.updateType(userId, userType);
   }

--- a/src/database/repositories/user.repository.ts
+++ b/src/database/repositories/user.repository.ts
@@ -47,6 +47,14 @@ export class UserRepository {
     return user ? toUserRow(user) : undefined;
   }
 
+  async findByEmail(email: string): Promise<UserRow | undefined> {
+    const normalizedEmail = email.toLowerCase().trim();
+    const user = await this.prisma.user.findFirst({
+      where: { email: { equals: normalizedEmail, mode: 'insensitive' } },
+    });
+    return user ? toUserRow(user) : undefined;
+  }
+
   async updateType(
     userId: string,
     userType: 'guardian' | 'ward',

--- a/src/database/repositories/ward.repository.ts
+++ b/src/database/repositories/ward.repository.ts
@@ -477,6 +477,7 @@ export class WardRepository {
       id: orgWard.id,
       organization_id: orgWard.organizationId,
       email: orgWard.email,
+      phone_number: orgWard.phoneNumber,
     };
   }
 

--- a/src/users/users.service.ts
+++ b/src/users/users.service.ts
@@ -53,6 +53,10 @@ export class UsersService {
         ? await this.dbService.findUserById(linkedGuardian.user_id)
         : null;
 
+      const linkedOrganization = ward?.organization_id
+        ? await this.dbService.findOrganizationById(ward.organization_id)
+        : null;
+
       return {
         ...baseResponse,
         wardInfo: ward
@@ -64,6 +68,12 @@ export class UsersService {
                     id: guardianUser.id,
                     nickname: guardianUser.nickname,
                     profileImageUrl: guardianUser.profile_image_url,
+                  }
+                : null,
+              linkedOrganization: linkedOrganization
+                ? {
+                    id: linkedOrganization.id,
+                    name: linkedOrganization.name,
                   }
                 : null,
             }


### PR DESCRIPTION
## 개요
카카오 로그인 시 에러 처리 개선 및 어르신 가입 시 정보 동기화 로직 추가

## 변경 사항

### 1. 로그인 에러 처리 개선 (auth.service.ts)
- 보호자 로그인 시도 시 이메일이 이미 ward로 등록되어 있는지 체크
  - users 테이블에서 ward 타입으로 등록된 사용자 확인
  - organization_wards 테이블에서 사전 등록된 이메일 확인
  - guardians 테이블에서 다른 보호자가 등록한 어르신 이메일 확인
- 적절한 에러 메시지 반환으로 iOS 클라이언트에서 사용자 안내 가능

### 2. 어르신 가입 시 전화번호 동기화 (auth.service.ts)
- 기관(organization_wards) 또는 보호자(guardians)가 등록한 전화번호를 wards 테이블로 복사
- 기존에는 빈 문자열로 저장되던 문제 수정

### 3. /users/me API 개선 (users.service.ts)
- wardInfo에 linkedOrganization 필드 추가
- 어르신이 소속된 기관 정보 반환

### 4. findUserByEmail 메서드 추가
- user.repository.ts: 이메일로 사용자 조회 기능 추가
- db.service.ts: facade 메서드 추가

### 5. findPendingOrganizationWardByEmail 반환값 확장
- ward.repository.ts: phone_number 필드 추가 반환

## 테스트 결과
- [x] npm run build 성공
- [x] npm test 성공

## 관련 이슈
Closes #46