### PR TITLE
[Feature] 전화 방향별 다른 인사말 지원

### DIFF
--- a/agents/voice/userdata.py
+++ b/agents/voice/userdata.py
@@ -2,6 +2,10 @@
 import logging
 from dataclasses import dataclass, field
 from datetime import datetime
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from agents.elderly_companion import CallDirection
 
 logger = logging.getLogger(__name__)
 
@@ -27,6 +31,7 @@ class SessionUserdata:
     """
     ward_id: str
     call_id: str
+    call_direction: str = "inbound"  # "inbound" or "outbound"
     transcripts: list[TranscriptEntry] = field(default_factory=list)
     session_start: datetime = field(default_factory=datetime.now)
 


### PR DESCRIPTION
## 📋 변경 사항

- SessionUserdata에 `call_direction` 필드 추가 (inbound/outbound)
- ElderlyCompanionAgent에 `on_enter()` 메서드 구현으로 첫 인사말 자동화
- 전화 방향별 다른 인사말 사용:
  - Outbound (agent가 전화 걸 때): "안녕하세요 어르신, 저 소담이에요."
  - Inbound (user가 전화 걸 때): "네, 여보세요. 소담입니다."
- Room name의 'bot-' prefix로 outbound/inbound 자동 판별
- TTS가 올바르게 읽도록 특수문자(~, !) 제거, 쉼표/마침표만 사용

## 🔗 관련 이슈

Closes #58

## ✅ 체크리스트
- [x] Python 문법 체크 완료
- [x] 브랜치/커밋 규칙 준수
- [x] 변경 사항 설명 작성