### PR TITLE
fix(agent): simple_agent.py NameError 수정

### DIFF
--- a/agents/voice/simple_agent.py
+++ b/agents/voice/simple_agent.py
@@ -563,16 +563,6 @@ async def entrypoint(ctx: JobContext):
     # Wait for participant to join
     await asyncio.sleep(3)
 
-    if participants:
-        logger.warning("Bot not found in time; using first participant")
-        return participants[0].identity
-
-    if asyncio.get_running_loop().time() >= deadline:
-        logger.warning("No participants joined before timeout")
-        return None
-
-    await asyncio.sleep(0.2)
-
     bot_identity = await wait_for_bot_identity()
     # Find target participant to listen to
     # Priority: 1) bot-* participant, 2) first non-admin participant, 3) None (listen to all)


### PR DESCRIPTION
## Summary
- Agent 시작 시 발생하던 `NameError: name 'participants' is not defined` 오류 수정
- 이전 리팩토링에서 남은 orphaned code 블록 삭제 (566-574 라인)

## Changes
- `agents/voice/simple_agent.py`: 정의되지 않은 `participants` 변수 참조하는 고아 코드 제거

## Test plan
- [x] Agent 컨테이너 정상 시작 확인
- [x] LiveKit worker 등록 확인
- [x] VAD 모델 로드 완료 확인

Closes #69