### PR TITLE
feat(docker): add agent service to docker-compose.dev.yml

### DIFF
--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -74,6 +74,16 @@ services:
     command: sh -c "npm install && npm run dev"
     restart: unless-stopped
 
+  agent:
+    build:
+      context: ../ops-agent
+    env_file: ../ops-agent/.env
+    network_mode: host
+    depends_on:
+      redis:
+        condition: service_healthy
+    restart: unless-stopped
+
 volumes:
   caddy_data:
   caddy_config:


### PR DESCRIPTION
## Summary
- ops-agent 서비스를 docker-compose.dev.yml에 추가
- ops-infra 대신 ops-api에서 로컬 개발 환경 통합 관리

## Changes
- agent 서비스 추가 (build context: ../ops-agent)
- network_mode: host 설정
- redis 의존성 추가

Closes #79