### PR TITLE
feat(livekit): AGENT_NAME 환경변수 지원으로 인스턴스별 Agent Dispatch

### DIFF
--- a/api.env.example
+++ b/api.env.example
@@ -2,9 +2,9 @@
 # LiveKit Server Connection
 # 테라폼 활용; 공유서버
 LIVEKIT_URL=https://livekit.sodam.store
-LIVEKIT_PUBLIC_URL=wss://livekit.sodam.store
 REDIS_URL=<redis://redis:6379>
 DATABASE_URL=<postgres://damso:de21a66b81fde0b7d5d3565bbfcb5b84@db:5432/damso>
+AGENT_NAME=voice-agent-N  # N = 인스턴스 번호 (개발), 프로덕션에서는 voice-agent
 
 # prod에서 변경
 API_AUTH_REQUIRED=false

--- a/src/integration/livekit/livekit.service.ts
+++ b/src/integration/livekit/livekit.service.ts
@@ -107,8 +107,9 @@ export class LiveKitService {
     metadata?: Record<string, unknown>,
   ): Promise<void> {
     try {
+      const agentName = process.env.AGENT_NAME || 'voice-agent';
       const metadataStr = metadata ? JSON.stringify(metadata) : undefined;
-      await this.agentDispatch.createDispatch(roomName, 'voice-agent', {
+      await this.agentDispatch.createDispatch(roomName, agentName, {
         metadata: metadataStr,
       });
       this.logger.log(`Voice agent dispatched to room=${roomName}`);


### PR DESCRIPTION
## 요약

다중 개발 인스턴스 환경에서 Agent Dispatch 충돌 문제 해결을 위해 `AGENT_NAME` 환경변수 지원 추가

## 변경 사항

- `src/integration/livekit/livekit.service.ts`: `dispatchVoiceAgent`에서 환경변수로 agent 이름 읽기
- `api.env.example`: `AGENT_NAME` 환경변수 추가

## 배경

현재 API 서버가 Agent Dispatch 시 `'voice-agent'`를 하드코딩하여 사용.
개발 환경에서 인스턴스별 고유 agent 이름을 지정해야 올바른 agent로 라우팅됨.

## 테스트 방법

1. `.env`에 `AGENT_NAME=voice-agent-N` 설정 (N = 인스턴스 번호)
2. 통화 시작 시 해당 agent로 dispatch되는지 확인

## 관련 문서

- `docs/dev-architecture.md`

## 관련 PR

- ops-agent: https://github.com/Namanmoo-Damso/ops-agent/pull/5