### PR TITLE
feature: 위험 상태 web으로 송신 구현

### DIFF
--- a/src/events/events.service.ts
+++ b/src/events/events.service.ts
@@ -14,10 +14,12 @@ export type RoomEvent = {
     | 'room-created'
     | 'room-updated'
     | 'participant-joined'
-    | 'participant-left';
+    | 'participant-left'
+    | 'room-danger';
   roomName: string;
   identity?: string;
   name?: string;
+  isDanger?: boolean;
   timestamp: string;
 };
 


### PR DESCRIPTION
✨ 기능 설명

관제자가 LiveKit 영상 타일에서 특정 room을 선택하여 위험 상태를 제어할 수 있는 API를 추가한다.
해당 API를 통해 room의 위험 상태를 변경하면, 연결된 타일 UI에 즉시 반영되어 관제가 용이해진다.

📡 API 요구사항

-특정 LiveKit room을 식별하여 상태 변경 가능
-room 상태를 NORMAL / DANGER 등으로 설정 가능

🔧 구현 내용

-roomId 기반 위험 상태 변경 API 신규 추가
-room 상태를 관리하는 서버 측 state 또는 store 연동
-LiveKit tile 컴포넌트에서 room 상태를 구독하여 UI 갱신

Closes #67 