### PR TITLE
fix: Redis 에러 핸들러 추가 및 서버 크래시 방지

### DIFF
--- a/src/ai/transcript.store.ts
+++ b/src/ai/transcript.store.ts
@@ -33,6 +33,12 @@ export class TranscriptStore {
     }
 
     this.client = createClient({ url: this.redisUrl });
+
+    // Handle connection errors to prevent unhandled 'error' events
+    this.client.on('error', (error) => {
+      this.logger.warn(`Redis client error: ${error.message}`);
+    });
+
     this.connecting = this.client
       .connect()
       .then(() => this.client)


### PR DESCRIPTION
transcript.store.ts (lines 38-40): Redis 클라이언트 초기화 로직에 .on('error', ...) 이벤트 핸들러를 추가했습니다.

이제 연결 문제가 발생해도 프로세스가 종료되지 않고, 에러 로그를 출력하며 클라이언트가 자동으로 재연결을 시도할 수 있도록 안정성을 확보했습니다.

close #85 