### PR TITLE
feat(care-alerts): Care Alerts 모듈 및 보호자-피보호자 관리 기능 구현

### DIFF
--- a/api.env.example
+++ b/api.env.example
@@ -1,3 +1,6 @@
+# Timezone
+TZ=Asia/Seoul
+
 # >>>>>>>>>>>>>>>>>>>>>>>>>>>>>> 변경해야 할 값들
 # LiveKit Server Connection
 # 테라폼 활용; 공유서버

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -38,7 +38,11 @@ services:
   api:
     image: node:20-alpine
     working_dir: /app
-    env_file: ./api.env
+    env_file: ./.env
+    environment:
+      - TZ=Asia/Seoul
+      - DATABASE_URL=postgres://damso:de21a66b81fde0b7d5d3565bbfcb5b84@db:5432/damso
+      - REDIS_URL=redis://redis:6379
     extra_hosts:
       - 'host.docker.internal:host-gateway'
     volumes:
@@ -64,6 +68,8 @@ services:
     image: node:20-alpine
     working_dir: /app
     env_file: ../ops-web/web.env
+    environment:
+      - TZ=Asia/Seoul
     volumes:
       - ../ops-web:/app # 소스 코드 마운트
       - /app/node_modules # 컨테이너 내부 의존성 보호

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -38,11 +38,7 @@ services:
   api:
     image: node:20-alpine
     working_dir: /app
-    env_file: ./.env
-    environment:
-      - TZ=Asia/Seoul
-      - DATABASE_URL=postgres://damso:de21a66b81fde0b7d5d3565bbfcb5b84@db:5432/damso
-      - REDIS_URL=redis://redis:6379
+    env_file: ./api.env
     extra_hosts:
       - 'host.docker.internal:host-gateway'
     volumes:
@@ -68,8 +64,6 @@ services:
     image: node:20-alpine
     working_dir: /app
     env_file: ../ops-web/web.env
-    environment:
-      - TZ=Asia/Seoul
     volumes:
       - ../ops-web:/app # 소스 코드 마운트
       - /app/node_modules # 컨테이너 내부 의존성 보호

--- a/init-db.sql
+++ b/init-db.sql
@@ -64,8 +64,6 @@ CREATE TABLE "organizations" (
 CREATE TABLE "guardians" (
     "id" UUID NOT NULL DEFAULT gen_random_uuid(),
     "user_id" UUID NOT NULL,
-    "ward_email" TEXT NOT NULL,
-    "ward_phone_number" TEXT NOT NULL,
     "created_at" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
     "updated_at" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
 
@@ -185,6 +183,15 @@ CREATE TABLE "guardian_ward_registrations" (
     "linked_ward_id" UUID,
     "created_at" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
     "updated_at" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    -- Ward Basic Info
+    "ward_name" TEXT,
+    "relation" TEXT,
+    "birth_date" TEXT,
+    "gender" TEXT,
+    "address" TEXT,
+    -- AI Care Info
+    "medical_conditions" TEXT,
+    "medications" TEXT,
 
     CONSTRAINT "guardian_ward_registrations_pkey" PRIMARY KEY ("id")
 );
@@ -202,6 +209,20 @@ CREATE TABLE "call_schedules" (
     "updated_at" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
 
     CONSTRAINT "call_schedules_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable: call_schedule_groups
+CREATE TABLE "call_schedule_groups" (
+    "id" UUID NOT NULL DEFAULT gen_random_uuid(),
+    "registration_id" UUID,
+    "ward_id" UUID,
+    "time" TEXT NOT NULL,
+    "weekdays" INTEGER[],
+    "is_enabled" BOOLEAN NOT NULL DEFAULT true,
+    "created_at" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updated_at" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "call_schedule_groups_pkey" PRIMARY KEY ("id")
 );
 
 -- CreateTable: organization_wards (includes gender and ward_type from migration 20260105183600)
@@ -374,6 +395,39 @@ CREATE TABLE "conversation_vectors" (
     CONSTRAINT "conversation_vectors_pkey" PRIMARY KEY ("id")
 );
 
+-- CreateTable: care_alert_events (케어 알림 이벤트 로그)
+CREATE TABLE "care_alert_events" (
+    "id" UUID NOT NULL DEFAULT gen_random_uuid(),
+    "ward_id" UUID NOT NULL,
+    "alert_type" VARCHAR(20) NOT NULL,
+    "severity" VARCHAR(10) NOT NULL,
+    "timestamp" TIMESTAMPTZ NOT NULL,
+    "raw_payload" JSONB NOT NULL,
+    "acknowledged" BOOLEAN DEFAULT FALSE,
+    "acknowledged_at" TIMESTAMPTZ,
+    "acknowledged_by" UUID,
+    "created_at" TIMESTAMPTZ DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "care_alert_events_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable: emotion_summaries (감정 10분 집계)
+CREATE TABLE "emotion_summaries" (
+    "id" UUID NOT NULL DEFAULT gen_random_uuid(),
+    "ward_id" UUID NOT NULL,
+    "period_start" TIMESTAMPTZ NOT NULL,
+    "period_end" TIMESTAMPTZ NOT NULL,
+    "total_samples" INTEGER NOT NULL,
+    "emotion_distribution" JSONB NOT NULL,
+    "average_confidence" DECIMAL(4, 3) NOT NULL,
+    "negative_ratio" DECIMAL(4, 3) NOT NULL,
+    "dominant_emotion" VARCHAR(20) NOT NULL,
+    "created_at" TIMESTAMPTZ DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "emotion_summaries_pkey" PRIMARY KEY ("id"),
+    CONSTRAINT "emotion_summaries_ward_id_period_start_key" UNIQUE ("ward_id", "period_start")
+);
+
 -- ============================================================================
 -- INDEXES
 -- ============================================================================
@@ -395,7 +449,6 @@ CREATE INDEX "devices_env_idx" ON "devices"("env");
 -- Guardians indexes
 CREATE UNIQUE INDEX "guardians_user_id_key" ON "guardians"("user_id");
 CREATE INDEX "guardians_user_id_idx" ON "guardians"("user_id");
-CREATE INDEX "guardians_ward_email_idx" ON "guardians"("ward_email");
 
 -- Wards indexes
 CREATE UNIQUE INDEX "wards_user_id_key" ON "wards"("user_id");
@@ -443,6 +496,11 @@ CREATE INDEX "guardian_ward_registrations_linked_ward_id_idx" ON "guardian_ward_
 CREATE INDEX "call_schedules_ward_id_idx" ON "call_schedules"("ward_id");
 CREATE INDEX "call_schedules_day_of_week_idx" ON "call_schedules"("day_of_week");
 CREATE INDEX "call_schedules_is_active_idx" ON "call_schedules"("is_active");
+
+-- Call schedule groups indexes
+CREATE INDEX "call_schedule_groups_registration_id_idx" ON "call_schedule_groups"("registration_id");
+CREATE INDEX "call_schedule_groups_ward_id_idx" ON "call_schedule_groups"("ward_id");
+CREATE INDEX "call_schedule_groups_is_enabled_idx" ON "call_schedule_groups"("is_enabled");
 
 -- Organization wards indexes
 CREATE INDEX "organization_wards_organization_id_idx" ON "organization_wards"("organization_id");
@@ -510,6 +568,15 @@ CREATE INDEX "conversation_vectors_ward_id_created_at_idx" ON "conversation_vect
 -- HNSW index for fast vector similarity search (m=16, ef_construction=64)
 CREATE INDEX "conversation_vectors_embedding_idx" ON "conversation_vectors" USING hnsw (embedding vector_cosine_ops) WITH (m = 16, ef_construction = 64);
 
+-- Care alert events indexes
+CREATE INDEX "care_alert_events_ward_id_timestamp_idx" ON "care_alert_events"("ward_id", "timestamp" DESC);
+CREATE INDEX "care_alert_events_alert_type_idx" ON "care_alert_events"("alert_type");
+CREATE INDEX "care_alert_events_severity_idx" ON "care_alert_events"("severity");
+CREATE INDEX "care_alert_events_acknowledged_idx" ON "care_alert_events"("acknowledged");
+
+-- Emotion summaries indexes
+CREATE INDEX "emotion_summaries_ward_id_period_start_idx" ON "emotion_summaries"("ward_id", "period_start" DESC);
+
 -- ============================================================================
 -- FOREIGN KEYS
 -- ============================================================================
@@ -532,6 +599,8 @@ ALTER TABLE "refresh_tokens" ADD CONSTRAINT "refresh_tokens_user_id_fkey" FOREIG
 ALTER TABLE "guardian_ward_registrations" ADD CONSTRAINT "guardian_ward_registrations_guardian_id_fkey" FOREIGN KEY ("guardian_id") REFERENCES "guardians"("id") ON DELETE CASCADE ON UPDATE CASCADE;
 ALTER TABLE "guardian_ward_registrations" ADD CONSTRAINT "guardian_ward_registrations_linked_ward_id_fkey" FOREIGN KEY ("linked_ward_id") REFERENCES "wards"("id") ON DELETE SET NULL ON UPDATE CASCADE;
 ALTER TABLE "call_schedules" ADD CONSTRAINT "call_schedules_ward_id_fkey" FOREIGN KEY ("ward_id") REFERENCES "wards"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+ALTER TABLE "call_schedule_groups" ADD CONSTRAINT "call_schedule_groups_registration_id_fkey" FOREIGN KEY ("registration_id") REFERENCES "guardian_ward_registrations"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+ALTER TABLE "call_schedule_groups" ADD CONSTRAINT "call_schedule_groups_ward_id_fkey" FOREIGN KEY ("ward_id") REFERENCES "wards"("id") ON DELETE CASCADE ON UPDATE CASCADE;
 ALTER TABLE "organization_wards" ADD CONSTRAINT "organization_wards_organization_id_fkey" FOREIGN KEY ("organization_id") REFERENCES "organizations"("id") ON DELETE CASCADE ON UPDATE CASCADE;
 ALTER TABLE "organization_wards" ADD CONSTRAINT "organization_wards_uploaded_by_admin_id_fkey" FOREIGN KEY ("uploaded_by_admin_id") REFERENCES "admins"("id") ON DELETE SET NULL ON UPDATE CASCADE;
 ALTER TABLE "organization_wards" ADD CONSTRAINT "organization_wards_ward_id_fkey" FOREIGN KEY ("ward_id") REFERENCES "wards"("id") ON DELETE SET NULL ON UPDATE CASCADE;
@@ -548,3 +617,9 @@ ALTER TABLE "admin_refresh_tokens" ADD CONSTRAINT "admin_refresh_tokens_admin_id
 ALTER TABLE "transcripts" ADD CONSTRAINT "transcripts_call_id_fkey" FOREIGN KEY ("call_id") REFERENCES "calls"("call_id") ON DELETE CASCADE ON UPDATE CASCADE;
 ALTER TABLE "conversation_vectors" ADD CONSTRAINT "conversation_vectors_ward_id_fkey" FOREIGN KEY ("ward_id") REFERENCES "wards"("id") ON DELETE CASCADE ON UPDATE CASCADE;
 ALTER TABLE "conversation_vectors" ADD CONSTRAINT "conversation_vectors_call_id_fkey" FOREIGN KEY ("call_id") REFERENCES "calls"("call_id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- Care alert events foreign keys
+ALTER TABLE "care_alert_events" ADD CONSTRAINT "care_alert_events_ward_id_fkey" FOREIGN KEY ("ward_id") REFERENCES "wards"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- Emotion summaries foreign keys
+ALTER TABLE "emotion_summaries" ADD CONSTRAINT "emotion_summaries_ward_id_fkey" FOREIGN KEY ("ward_id") REFERENCES "wards"("id") ON DELETE CASCADE ON UPDATE CASCADE;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -83,12 +83,10 @@ model Organization {
 // 4. GUARDIANS
 // =============================================================================
 model Guardian {
-  id              String   @id @default(dbgenerated("gen_random_uuid()")) @db.Uuid
-  userId          String   @unique @map("user_id") @db.Uuid
-  wardEmail       String   @map("ward_email")
-  wardPhoneNumber String   @map("ward_phone_number")
-  createdAt       DateTime @default(now()) @map("created_at")
-  updatedAt       DateTime @default(now()) @updatedAt @map("updated_at")
+  id        String   @id @default(dbgenerated("gen_random_uuid()")) @db.Uuid
+  userId    String   @unique @map("user_id") @db.Uuid
+  createdAt DateTime @default(now()) @map("created_at")
+  updatedAt DateTime @default(now()) @updatedAt @map("updated_at")
 
   // Relations
   user                      User                       @relation(fields: [userId], references: [id], onDelete: Cascade)
@@ -97,7 +95,6 @@ model Guardian {
   guardianWardRegistrations GuardianWardRegistration[]
 
   @@index([userId])
-  @@index([wardEmail])
   @@map("guardians")
 }
 
@@ -123,11 +120,14 @@ model Ward {
   callSummaries             CallSummary[]
   healthAlerts              HealthAlert[]
   callSchedules             CallSchedule[]
+  callScheduleGroups        CallScheduleGroup[]        @relation("WardCallScheduleGroups")
   organizationWards         OrganizationWard[]
   wardLocations             WardLocation[]
   wardCurrentLocation       WardCurrentLocation?
   emergencies               Emergency[]
   guardianWardRegistrations GuardianWardRegistration[]
+  careAlertEvents           CareAlertEvent[]
+  emotionSummaries          EmotionSummary[]
 
   @@index([userId])
   @@index([guardianId])
@@ -290,9 +290,21 @@ model GuardianWardRegistration {
   createdAt       DateTime @default(now()) @map("created_at")
   updatedAt       DateTime @default(now()) @updatedAt @map("updated_at")
 
+  // Ward Basic Info (from iOS wardBasicInfo)
+  wardName  String?  @map("ward_name")   // 어르신 성함
+  relation  String?                       // 관계: parent, grandparent, spouse, relative, other
+  birthDate String?  @map("birth_date")  // 생년월일 (YYYYMMDD)
+  gender    String?                       // 성별: male, female
+  address   String?                       // 거주지 주소
+
+  // AI Care Info (from iOS aiCareInfo)
+  medicalConditions String? @map("medical_conditions") // 기저질환
+  medications       String?                             // 복용 약
+
   // Relations
-  guardian   Guardian @relation(fields: [guardianId], references: [id], onDelete: Cascade)
-  linkedWard Ward?    @relation(fields: [linkedWardId], references: [id], onDelete: SetNull)
+  guardian       Guardian                @relation(fields: [guardianId], references: [id], onDelete: Cascade)
+  linkedWard     Ward?                   @relation(fields: [linkedWardId], references: [id], onDelete: SetNull)
+  callSchedules  CallScheduleGroup[]
 
   @@index([guardianId])
   @@index([wardEmail])
@@ -301,7 +313,7 @@ model GuardianWardRegistration {
 }
 
 // =============================================================================
-// 14. CALL_SCHEDULES
+// 14. CALL_SCHEDULES (Legacy - 요일별 개별 레코드)
 // =============================================================================
 model CallSchedule {
   id             String    @id @default(dbgenerated("gen_random_uuid()")) @db.Uuid
@@ -321,6 +333,29 @@ model CallSchedule {
   @@index([dayOfWeek])
   @@index([isActive])
   @@map("call_schedules")
+}
+
+// =============================================================================
+// 14-1. CALL_SCHEDULE_GROUPS (iOS 앱용 - 하나의 스케줄에 여러 요일)
+// =============================================================================
+model CallScheduleGroup {
+  id             String   @id @default(dbgenerated("gen_random_uuid()")) @db.Uuid
+  registrationId String?  @map("registration_id") @db.Uuid  // 연동 전 (GuardianWardRegistration)
+  wardId         String?  @map("ward_id") @db.Uuid          // 연동 후 (Ward)
+  time           String                                      // "10:00" 형식
+  weekdays       Int[]                                       // [0,1,2,3,4,5,6] - 0=일, 6=토
+  isEnabled      Boolean  @default(true) @map("is_enabled")
+  createdAt      DateTime @default(now()) @map("created_at")
+  updatedAt      DateTime @default(now()) @updatedAt @map("updated_at")
+
+  // Relations
+  registration GuardianWardRegistration? @relation(fields: [registrationId], references: [id], onDelete: Cascade)
+  ward         Ward?                      @relation("WardCallScheduleGroups", fields: [wardId], references: [id], onDelete: Cascade)
+
+  @@index([registrationId])
+  @@index([wardId])
+  @@index([isEnabled])
+  @@map("call_schedule_groups")
 }
 
 // =============================================================================
@@ -589,4 +624,52 @@ model ConversationVector {
   @@index([createdAt])
   // HNSW index for vector similarity search (created via migration SQL)
   @@map("conversation_vectors")
+}
+
+// =============================================================================
+// 26. CARE_ALERT_EVENTS - Fall/LoudVoice 이벤트 로그
+// =============================================================================
+model CareAlertEvent {
+  id             String    @id @default(dbgenerated("gen_random_uuid()")) @db.Uuid
+  wardId         String    @map("ward_id") @db.Uuid
+  alertType      String    @map("alert_type")   // device_fall | person_fall | loud_voice
+  severity       String                          // low | medium | high | critical
+  timestamp      DateTime                        // 이벤트 발생 시각 (iOS에서 전송)
+  rawPayload     Json      @map("raw_payload")
+  acknowledged   Boolean   @default(false)
+  acknowledgedAt DateTime? @map("acknowledged_at")
+  acknowledgedBy String?   @map("acknowledged_by") @db.Uuid
+  createdAt      DateTime  @default(now()) @map("created_at")
+
+  // Relations
+  ward Ward @relation(fields: [wardId], references: [id], onDelete: Cascade)
+
+  @@index([wardId, timestamp(sort: Desc)])
+  @@index([alertType])
+  @@index([severity])
+  @@index([acknowledged])
+  @@map("care_alert_events")
+}
+
+// =============================================================================
+// 27. EMOTION_SUMMARIES - 감정 10분 집계
+// =============================================================================
+model EmotionSummary {
+  id                  String   @id @default(dbgenerated("gen_random_uuid()")) @db.Uuid
+  wardId              String   @map("ward_id") @db.Uuid
+  periodStart         DateTime @map("period_start")
+  periodEnd           DateTime @map("period_end")
+  totalSamples        Int      @map("total_samples")
+  emotionDistribution Json     @map("emotion_distribution") // { neutral: 0.45, happy: 0.30, ... }
+  averageConfidence   Decimal  @map("average_confidence") @db.Decimal(4, 3)
+  negativeRatio       Decimal  @map("negative_ratio") @db.Decimal(4, 3)
+  dominantEmotion     String   @map("dominant_emotion")
+  createdAt           DateTime @default(now()) @map("created_at")
+
+  // Relations
+  ward Ward @relation(fields: [wardId], references: [id], onDelete: Cascade)
+
+  @@unique([wardId, periodStart])
+  @@index([wardId, periodStart(sort: Desc)])
+  @@map("emotion_summaries")
 }

--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -18,6 +18,7 @@ import { PrismaModule } from './prisma';
 import { EventsModule } from './events';
 import { ConfigModule } from './core/config';
 import { LiveKitModule } from './integration/livekit';
+import { CareAlertsModule } from './care-alerts';
 
 @Module({
   imports: [
@@ -41,6 +42,7 @@ import { LiveKitModule } from './integration/livekit';
     DevicesModule,
     AdminModule,
     SchedulerModule,
+    CareAlertsModule,
   ],
   controllers: [AppController, PushController],
   providers: [],

--- a/src/auth/auth.controller.ts
+++ b/src/auth/auth.controller.ts
@@ -9,7 +9,12 @@ import {
 } from '@nestjs/common';
 import { AuthService } from './auth.service';
 import { LiveKitService } from '../integration/livekit';
-import { KakaoLoginDto, RefreshTokenDto, AnonymousAuthDto } from './dto';
+import {
+  KakaoLoginDto,
+  RefreshTokenDto,
+  AnonymousAuthDto,
+  DevGuardianDto,
+} from './dto';
 import { DbService } from '../database';
 import { EventsService } from '../events';
 
@@ -137,6 +142,49 @@ export class AuthController {
       throw new HttpException(
         'Logout failed',
         HttpStatus.INTERNAL_SERVER_ERROR,
+      );
+    }
+  }
+
+  /**
+   * 개발용: 카카오 로그인 없이 보호자 계정 생성 + 토큰 발급
+   * 프로덕션에서는 사용 금지
+   */
+  @Post('dev/guardian')
+  async devRegisterGuardian(@Body() body: DevGuardianDto) {
+    // 프로덕션 환경 체크
+    if (process.env.NODE_ENV === 'production') {
+      throw new HttpException(
+        'This endpoint is not available in production',
+        HttpStatus.FORBIDDEN,
+      );
+    }
+
+    const wardEmail = body.wardEmail?.trim();
+
+    if (!wardEmail) {
+      throw new HttpException('wardEmail is required', HttpStatus.BAD_REQUEST);
+    }
+
+    try {
+      this.logger.log(`devRegisterGuardian wardEmail=${wardEmail}`);
+      const result = await this.authService.devRegisterGuardian({
+        wardEmail,
+        wardPhoneNumber: body.wardPhoneNumber?.trim(),
+        wardBasicInfo: body.wardBasicInfo,
+        aiCareInfo: body.aiCareInfo,
+        callSchedule: body.callSchedule,
+        nickname: body.nickname,
+        email: body.email,
+      });
+      return result;
+    } catch (error) {
+      this.logger.error(
+        `devRegisterGuardian failed error=${(error as Error).message}`,
+      );
+      throw new HttpException(
+        (error as Error).message || 'Registration failed',
+        HttpStatus.BAD_REQUEST,
       );
     }
   }

--- a/src/auth/auth.service.ts
+++ b/src/auth/auth.service.ts
@@ -88,14 +88,19 @@ type KakaoLoginResult =
     };
 
 type GuardianRegistrationResult = {
+  isNewUser: boolean;
   accessToken: string;
   refreshToken: string;
   user: UserInfo;
   guardianInfo: {
     id: string;
-    wardEmail: string;
-    wardPhoneNumber: string;
-    linkedWard: null;
+    wards: Array<{
+      registrationId: string;
+      wardEmail: string;
+      wardPhoneNumber: string;
+      linkedWardId: string | null;
+      wardNickname: string | null;
+    }>;
   };
 };
 
@@ -153,6 +158,23 @@ export class AuthService {
 
       // 기존 사용자 - JWT 발급
       this.logger.log(`kakaoLogin existing user id=${existingUser.id}`);
+
+      // 보호자인 경우 미연동 어르신 자동 연동
+      if (existingUser.user_type === 'guardian') {
+        const guardian = await this.dbService.findGuardianByUserId(
+          existingUser.id,
+        );
+        if (guardian) {
+          const linkedCount =
+            await this.dbService.linkPendingWardsForGuardian(guardian.id);
+          if (linkedCount > 0) {
+            this.logger.log(
+              `kakaoLogin auto-linked ${linkedCount} wards for guardian=${guardian.id}`,
+            );
+          }
+        }
+      }
+
       const tokens = await this.issueTokens(
         existingUser.id,
         existingUser.user_type as UserType,
@@ -454,6 +476,27 @@ export class AuthService {
     accessToken: string;
     wardEmail: string;
     wardPhoneNumber: string;
+    wardBasicInfo?: {
+      name?: string;
+      relation?: string;
+      phoneNumber?: string;
+      birthDate?: string;
+      gender?: string;
+      address?: string;
+    };
+    aiCareInfo?: {
+      medicalConditions?: string;
+      medications?: string;
+    };
+    callSchedule?: {
+      isEnabled: boolean;
+      items: Array<{
+        id?: string;
+        time: string;
+        weekdays: number[];
+        isEnabled: boolean;
+      }>;
+    };
   }): Promise<GuardianRegistrationResult> {
     // 1. Access Token 검증
     const payload = this.verifyAccessToken(params.accessToken);
@@ -472,20 +515,24 @@ export class AuthService {
       throw new UnauthorizedException('User already registered as guardian');
     }
 
-    // 4. 트랜잭션으로 사용자 타입 변경 + 보호자 정보 생성
-    const { guardian } = await this.dbService.registerGuardianWithTransaction({
+    // 4. 트랜잭션으로 사용자 타입 변경 + 보호자 정보 + 어르신 등록 정보 생성
+    const { guardian, registration } = await this.dbService.registerGuardianWithTransaction({
       userId: user.id,
       wardEmail: params.wardEmail,
       wardPhoneNumber: params.wardPhoneNumber,
+      wardBasicInfo: params.wardBasicInfo,
+      aiCareInfo: params.aiCareInfo,
+      callSchedule: params.callSchedule,
     });
 
     // 5. 새 JWT 발급 (user_type이 변경되었으므로)
     const tokens = await this.issueTokens(user.id, 'guardian');
 
     this.logger.log(
-      `registerGuardian userId=${user.id} guardianId=${guardian.id}`,
+      `registerGuardian userId=${user.id} guardianId=${guardian.id} registrationId=${registration.id}`,
     );
     return {
+      isNewUser: true,
       ...tokens,
       user: {
         id: user.id,
@@ -496,9 +543,162 @@ export class AuthService {
       },
       guardianInfo: {
         id: guardian.id,
-        wardEmail: guardian.ward_email,
-        wardPhoneNumber: guardian.ward_phone_number,
-        linkedWard: null,
+        wards: [
+          {
+            registrationId: registration.id,
+            wardEmail: registration.ward_email,
+            wardPhoneNumber: registration.ward_phone_number,
+            linkedWardId: null,
+            wardNickname: null,
+          },
+        ],
+      },
+    };
+  }
+
+  /**
+   * 개발용: 카카오 로그인 없이 보호자 계정 생성 + 토큰 발급
+   * 프로덕션에서는 사용 금지
+   */
+  async devRegisterGuardian(params: {
+    wardEmail: string;
+    wardPhoneNumber?: string;
+    wardBasicInfo?: {
+      name?: string;
+      relation?: string;
+      phoneNumber?: string;
+      birthDate?: string;
+      gender?: string;
+      address?: string;
+    };
+    aiCareInfo?: {
+      medicalConditions?: string;
+      medications?: string;
+    };
+    callSchedule?: {
+      isEnabled: boolean;
+      items: Array<{
+        id?: string;
+        time: string;
+        weekdays: number[];
+        isEnabled: boolean;
+      }>;
+    };
+    nickname?: string;
+    email?: string;
+  }): Promise<GuardianRegistrationResult> {
+    // 1. 기존 guardian 확인 (wardEmail로 검색)
+    const existingGuardian = await this.dbService.findGuardianByWardEmail(
+      params.wardEmail,
+    );
+
+    if (existingGuardian) {
+      // 기존 guardian이 있으면 토큰만 발급
+      const user = await this.dbService.findUserById(existingGuardian.user_id);
+      if (!user) {
+        throw new Error('Guardian user not found');
+      }
+
+      // 미연동 어르신 자동 연동
+      const linkedCount = await this.dbService.linkPendingWardsForGuardian(
+        existingGuardian.id,
+      );
+      if (linkedCount > 0) {
+        this.logger.log(
+          `devRegisterGuardian auto-linked ${linkedCount} wards for guardian=${existingGuardian.id}`,
+        );
+      }
+
+      // 모든 어르신 목록 조회
+      const wards = await this.dbService.getGuardianWards(existingGuardian.id);
+
+      const tokens = await this.issueTokens(user.id, 'guardian');
+      this.logger.log(
+        `devRegisterGuardian existing guardian userId=${user.id} guardianId=${existingGuardian.id} wardsCount=${wards.length}`,
+      );
+
+      return {
+        isNewUser: false,
+        ...tokens,
+        user: {
+          id: user.id,
+          email: user.email,
+          nickname: user.nickname,
+          profileImageUrl: user.profile_image_url,
+          userType: 'guardian',
+        },
+        guardianInfo: {
+          id: existingGuardian.id,
+          wards: wards.map((w) => ({
+            registrationId: w.id,
+            wardEmail: w.ward_email,
+            wardPhoneNumber: w.ward_phone_number,
+            linkedWardId: w.linked_ward_id,
+            wardNickname: w.ward_nickname,
+          })),
+        },
+      };
+    }
+
+    // 2. 새 guardian 생성 - wardPhoneNumber 필수
+    if (!params.wardPhoneNumber) {
+      throw new Error('wardPhoneNumber is required for new guardian');
+    }
+
+    const dummyKakaoId = `dev_${Date.now()}_${Math.random().toString(36).substring(7)}`;
+    const nickname =
+      params.nickname || `테스트보호자_${Date.now().toString().slice(-4)}`;
+    const email = params.email || `dev_${Date.now()}@test.local`;
+
+    const user = await this.dbService.createUserWithKakao({
+      kakaoId: dummyKakaoId,
+      email,
+      nickname,
+      profileImageUrl: null,
+      userType: null,
+    });
+
+    this.logger.log(`devRegisterGuardian created dummy user id=${user.id}`);
+
+    // 3. Guardian + Registration 생성 (기존 로직 재사용)
+    const { guardian, registration } =
+      await this.dbService.registerGuardianWithTransaction({
+        userId: user.id,
+        wardEmail: params.wardEmail,
+        wardPhoneNumber: params.wardPhoneNumber,
+        wardBasicInfo: params.wardBasicInfo,
+        aiCareInfo: params.aiCareInfo,
+        callSchedule: params.callSchedule,
+      });
+
+    // 4. 토큰 발급
+    const tokens = await this.issueTokens(user.id, 'guardian');
+
+    this.logger.log(
+      `devRegisterGuardian userId=${user.id} guardianId=${guardian.id} registrationId=${registration.id}`,
+    );
+
+    return {
+      isNewUser: true,
+      ...tokens,
+      user: {
+        id: user.id,
+        email: user.email,
+        nickname: user.nickname,
+        profileImageUrl: user.profile_image_url,
+        userType: 'guardian',
+      },
+      guardianInfo: {
+        id: guardian.id,
+        wards: [
+          {
+            registrationId: registration.id,
+            wardEmail: registration.ward_email,
+            wardPhoneNumber: registration.ward_phone_number,
+            linkedWardId: null,
+            wardNickname: null,
+          },
+        ],
       },
     };
   }
@@ -608,7 +808,12 @@ export class AuthService {
       : '';
     if (!token) return null;
     try {
-      return this.verifyApiToken(token);
+      const payload = this.verifyApiToken(token);
+      // 카카오 로그인 JWT는 identity가 없으므로 sub를 폴백으로 사용
+      if (!payload.identity && payload.sub) {
+        payload.identity = payload.sub;
+      }
+      return payload;
     } catch {
       return null;
     }

--- a/src/auth/dto/dev-guardian.dto.ts
+++ b/src/auth/dto/dev-guardian.dto.ts
@@ -1,0 +1,32 @@
+/**
+ * 개발용 보호자 등록 DTO
+ * 카카오 로그인 없이 보호자 계정 생성 + 토큰 발급
+ */
+export class DevGuardianDto {
+  wardEmail: string;
+  wardPhoneNumber: string;
+  wardBasicInfo?: {
+    name?: string;
+    relation?: string;
+    phoneNumber?: string;
+    birthDate?: string;
+    gender?: string;
+    address?: string;
+  };
+  aiCareInfo?: {
+    medicalConditions?: string;
+    medications?: string;
+  };
+  callSchedule?: {
+    isEnabled: boolean;
+    items: Array<{
+      id?: string;
+      time: string;
+      weekdays: number[];
+      isEnabled: boolean;
+    }>;
+  };
+  // 더미 유저 정보 (optional)
+  nickname?: string;
+  email?: string;
+}

--- a/src/auth/dto/index.ts
+++ b/src/auth/dto/index.ts
@@ -1,3 +1,4 @@
 export * from './kakao-login.dto';
 export * from './refresh-token.dto';
 export * from './anonymous-auth.dto';
+export * from './dev-guardian.dto';

--- a/src/care-alerts/care-alerts.controller.ts
+++ b/src/care-alerts/care-alerts.controller.ts
@@ -1,0 +1,295 @@
+import {
+  Controller,
+  Get,
+  Post,
+  Patch,
+  Body,
+  Param,
+  Query,
+  Headers,
+  HttpException,
+  HttpStatus,
+  Logger,
+} from '@nestjs/common';
+import { CareAlertsService } from './care-alerts.service';
+import { AuthService } from '../auth';
+import { PrismaService } from '../prisma/prisma.service';
+import { CreateCareAlertDto } from './dto/create-care-alert.dto';
+
+@Controller('v1')
+export class CareAlertsController {
+  private readonly logger = new Logger(CareAlertsController.name);
+
+  constructor(
+    private readonly careAlertsService: CareAlertsService,
+    private readonly authService: AuthService,
+    private readonly prisma: PrismaService,
+  ) {}
+
+  private verifyAuthHeader(authorization: string | undefined) {
+    const authHeader = authorization ?? '';
+    const token = authHeader.startsWith('Bearer ')
+      ? authHeader.slice('Bearer '.length).trim()
+      : undefined;
+
+    if (!token) {
+      throw new HttpException(
+        'Access token is required',
+        HttpStatus.UNAUTHORIZED,
+      );
+    }
+
+    const payload = this.authService.verifyAccessToken(token);
+    if (!payload) {
+      throw new HttpException(
+        'Invalid or expired access token',
+        HttpStatus.UNAUTHORIZED,
+      );
+    }
+
+    return payload;
+  }
+
+  /**
+   * Ward용 - 케어 알림 수신
+   * POST /v1/care-alerts
+   */
+  @Post('care-alerts')
+  async createAlert(
+    @Headers('authorization') authorization: string | undefined,
+    @Body() dto: CreateCareAlertDto,
+  ) {
+    const payload = this.verifyAuthHeader(authorization);
+
+    this.logger.log(
+      `[API] POST /v1/care-alerts userId=${payload.sub} alertType=${dto.alertType}`,
+    );
+
+    try {
+      // userId로 wardId 조회
+      const ward = await this.prisma.ward.findUnique({
+        where: { userId: payload.sub },
+      });
+
+      if (!ward) {
+        this.logger.warn(
+          `[API] care-alerts ward not found for userId=${payload.sub}`,
+        );
+        throw new HttpException('Ward not found', HttpStatus.NOT_FOUND);
+      }
+
+      return await this.careAlertsService.processAlert(ward.id, dto);
+    } catch (error) {
+      if ((error as HttpException).getStatus?.()) {
+        throw error;
+      }
+      this.logger.error(
+        `[API] care-alerts error=${(error as Error).message}`,
+      );
+      throw new HttpException(
+        'Failed to process care alert',
+        HttpStatus.INTERNAL_SERVER_ERROR,
+      );
+    }
+  }
+
+  /**
+   * Guardian용 - 알림 목록 조회
+   * GET /v1/guardians/wards/:wardId/alerts
+   */
+  @Get('guardians/wards/:wardId/alerts')
+  async getAlerts(
+    @Headers('authorization') authorization: string | undefined,
+    @Param('wardId') wardId: string,
+    @Query('type') type?: string,
+    @Query('since') since?: string,
+    @Query('limit') limit?: string,
+  ) {
+    const payload = this.verifyAuthHeader(authorization);
+
+    this.logger.log(
+      `[API] GET /v1/guardians/wards/${wardId}/alerts userId=${payload.sub} type=${type ?? 'all'}`,
+    );
+
+    try {
+      // Guardian 권한 확인
+      await this.verifyGuardianAccess(payload.sub, wardId);
+
+      return await this.careAlertsService.getAlerts(wardId, {
+        type,
+        since,
+        limit: limit ? parseInt(limit, 10) : undefined,
+      });
+    } catch (error) {
+      if ((error as HttpException).getStatus?.()) {
+        throw error;
+      }
+      this.logger.error(
+        `[API] getAlerts error=${(error as Error).message}`,
+      );
+      throw new HttpException(
+        'Failed to get alerts',
+        HttpStatus.INTERNAL_SERVER_ERROR,
+      );
+    }
+  }
+
+  /**
+   * Guardian용 - 감정 리포트 조회
+   * GET /v1/guardians/wards/:wardId/emotion-report
+   */
+  @Get('guardians/wards/:wardId/emotion-report')
+  async getEmotionReport(
+    @Headers('authorization') authorization: string | undefined,
+    @Param('wardId') wardId: string,
+    @Query('date') date?: string,
+  ) {
+    const payload = this.verifyAuthHeader(authorization);
+
+    const targetDate = date ?? new Date().toISOString().split('T')[0];
+
+    this.logger.log(
+      `[API] GET /v1/guardians/wards/${wardId}/emotion-report userId=${payload.sub} date=${targetDate}`,
+    );
+
+    try {
+      // Guardian 권한 확인
+      await this.verifyGuardianAccess(payload.sub, wardId);
+
+      return await this.careAlertsService.getEmotionReport(wardId, targetDate);
+    } catch (error) {
+      if ((error as HttpException).getStatus?.()) {
+        throw error;
+      }
+      this.logger.error(
+        `[API] getEmotionReport error=${(error as Error).message}`,
+      );
+      throw new HttpException(
+        'Failed to get emotion report',
+        HttpStatus.INTERNAL_SERVER_ERROR,
+      );
+    }
+  }
+
+  /**
+   * Guardian용 - 알림 확인 처리
+   * PATCH /v1/guardians/alerts/:alertId/acknowledge
+   */
+  @Patch('guardians/alerts/:alertId/acknowledge')
+  async acknowledgeAlert(
+    @Headers('authorization') authorization: string | undefined,
+    @Param('alertId') alertId: string,
+  ) {
+    const payload = this.verifyAuthHeader(authorization);
+
+    this.logger.log(
+      `[API] PATCH /v1/guardians/alerts/${alertId}/acknowledge userId=${payload.sub}`,
+    );
+
+    try {
+      // Alert의 ward가 Guardian에게 연결되어 있는지 확인
+      const alert = await this.prisma.careAlertEvent.findUnique({
+        where: { id: alertId },
+        include: {
+          ward: {
+            include: {
+              guardian: true,
+            },
+          },
+        },
+      });
+
+      if (!alert) {
+        throw new HttpException('Alert not found', HttpStatus.NOT_FOUND);
+      }
+
+      // Guardian 권한 확인
+      const guardian = await this.prisma.guardian.findUnique({
+        where: { userId: payload.sub },
+      });
+
+      if (!guardian || alert.ward.guardianId !== guardian.id) {
+        throw new HttpException(
+          'Not authorized to acknowledge this alert',
+          HttpStatus.FORBIDDEN,
+        );
+      }
+
+      return await this.careAlertsService.acknowledgeAlert(alertId, payload.sub);
+    } catch (error) {
+      if ((error as HttpException).getStatus?.()) {
+        throw error;
+      }
+      this.logger.error(
+        `[API] acknowledgeAlert error=${(error as Error).message}`,
+      );
+      throw new HttpException(
+        'Failed to acknowledge alert',
+        HttpStatus.INTERNAL_SERVER_ERROR,
+      );
+    }
+  }
+
+  /**
+   * 디버깅용 - Emotion 버퍼 상태 조회
+   * GET /v1/care-alerts/buffer-status
+   */
+  @Get('care-alerts/buffer-status')
+  async getBufferStatus(
+    @Headers('authorization') authorization: string | undefined,
+    @Query('wardId') wardId?: string,
+  ) {
+    this.verifyAuthHeader(authorization);
+
+    this.logger.log(
+      `[API] GET /v1/care-alerts/buffer-status wardId=${wardId ?? 'all'}`,
+    );
+
+    return {
+      buffers: this.careAlertsService.getBufferStatus(wardId),
+      timestamp: new Date().toISOString(),
+    };
+  }
+
+  /**
+   * Guardian의 Ward 접근 권한 확인
+   */
+  private async verifyGuardianAccess(
+    userId: string,
+    wardId: string,
+  ): Promise<void> {
+    const guardian = await this.prisma.guardian.findUnique({
+      where: { userId },
+    });
+
+    if (!guardian) {
+      throw new HttpException('Guardian not found', HttpStatus.FORBIDDEN);
+    }
+
+    // Ward가 Guardian에게 연결되어 있는지 확인
+    const ward = await this.prisma.ward.findUnique({
+      where: { id: wardId },
+    });
+
+    if (!ward) {
+      throw new HttpException('Ward not found', HttpStatus.NOT_FOUND);
+    }
+
+    if (ward.guardianId !== guardian.id) {
+      // GuardianWardRegistration을 통한 연결 확인
+      const registration = await this.prisma.guardianWardRegistration.findFirst({
+        where: {
+          guardianId: guardian.id,
+          linkedWardId: wardId,
+        },
+      });
+
+      if (!registration) {
+        throw new HttpException(
+          'Not authorized to access this ward',
+          HttpStatus.FORBIDDEN,
+        );
+      }
+    }
+  }
+}

--- a/src/care-alerts/care-alerts.module.ts
+++ b/src/care-alerts/care-alerts.module.ts
@@ -1,0 +1,20 @@
+import { Module } from '@nestjs/common';
+import { ScheduleModule } from '@nestjs/schedule';
+import { CareAlertsController } from './care-alerts.controller';
+import { CareAlertsService } from './care-alerts.service';
+import { PrismaModule } from '../prisma/prisma.module';
+import { PushModule } from '../push/push.module';
+import { AuthModule } from '../auth';
+
+@Module({
+  imports: [
+    ScheduleModule.forRoot(),
+    PrismaModule,
+    PushModule,
+    AuthModule,
+  ],
+  controllers: [CareAlertsController],
+  providers: [CareAlertsService],
+  exports: [CareAlertsService],
+})
+export class CareAlertsModule {}

--- a/src/care-alerts/care-alerts.service.ts
+++ b/src/care-alerts/care-alerts.service.ts
@@ -1,0 +1,612 @@
+import { Injectable, Logger } from '@nestjs/common';
+import { Cron } from '@nestjs/schedule';
+import { Prisma } from '@prisma/client';
+import { PrismaService } from '../prisma/prisma.service';
+import { PushService } from '../push/push.service';
+import { EventsService } from '../events/events.service';
+import { CreateCareAlertDto } from './dto/create-care-alert.dto';
+import {
+  CareAlertCreatedResponse,
+  CareAlertEventResponse,
+  GetAlertsResponse,
+  EmotionReportResponse,
+  EmotionSummaryResponse,
+  AcknowledgeAlertResponse,
+} from './dto/care-alert-response.dto';
+import {
+  AlertType,
+  Severity,
+  EmotionType,
+  EmotionPayload,
+  EmotionBufferData,
+  EmotionAggregation,
+  IMMEDIATE_ALERT_CONDITIONS,
+  NEGATIVE_EMOTIONS,
+} from './types/care-alert.types';
+
+@Injectable()
+export class CareAlertsService {
+  private readonly logger = new Logger(CareAlertsService.name);
+
+  // wardId -> EmotionBufferData[] (10분 집계용 버퍼)
+  private emotionBuffers: Map<string, EmotionBufferData[]> = new Map();
+
+  constructor(
+    private readonly prisma: PrismaService,
+    private readonly pushService: PushService,
+    private readonly eventsService: EventsService,
+  ) {
+    this.logger.log('CareAlertsService initialized');
+  }
+
+  /**
+   * 케어 알림 처리 메인 로직
+   */
+  async processAlert(
+    wardId: string,
+    dto: CreateCareAlertDto,
+  ): Promise<CareAlertCreatedResponse> {
+    const startTime = Date.now();
+
+    // 상세 로그 - 수신 데이터
+    this.logger.log(
+      `[CARE_ALERT_RECEIVED] wardId=${wardId} alertType=${dto.alertType} severity=${dto.severity} timestamp=${dto.timestamp}`,
+    );
+    this.logger.debug(
+      `[CARE_ALERT_PAYLOAD] wardId=${wardId} data=${JSON.stringify(dto.data)}`,
+    );
+
+    try {
+      if (dto.alertType === 'emotion') {
+        return this.bufferEmotion(wardId, dto);
+      }
+
+      // Fall/LoudVoice → 원본 저장 + 즉시 알림
+      const event = await this.saveCareAlertEvent(wardId, dto);
+
+      // 즉시 알림 조건 확인
+      const shouldNotify = this.shouldSendImmediateNotification(
+        dto.alertType,
+        dto.severity,
+      );
+
+      if (shouldNotify) {
+        await this.sendNotifications(wardId, event);
+      }
+
+      const elapsed = Date.now() - startTime;
+      this.logger.log(
+        `[CARE_ALERT_PROCESSED] wardId=${wardId} alertType=${dto.alertType} alertId=${event.id} notified=${shouldNotify} elapsed=${elapsed}ms`,
+      );
+
+      return {
+        success: true,
+        alertType: dto.alertType,
+        processed: 'stored',
+        alertId: event.id,
+      };
+    } catch (error) {
+      this.logger.error(
+        `[CARE_ALERT_ERROR] wardId=${wardId} alertType=${dto.alertType} error=${error instanceof Error ? error.message : String(error)}`,
+      );
+      throw error;
+    }
+  }
+
+  /**
+   * Emotion 데이터 버퍼링 (10분 집계)
+   */
+  private bufferEmotion(
+    wardId: string,
+    dto: CreateCareAlertDto,
+  ): CareAlertCreatedResponse {
+    const payload = dto.data.payload as unknown as EmotionPayload;
+
+    const bufferData: EmotionBufferData = {
+      timestamp: dto.timestamp,
+      emotion: payload.emotion,
+      confidence: payload.confidence,
+      intensity: payload.intensity,
+    };
+
+    if (!this.emotionBuffers.has(wardId)) {
+      this.emotionBuffers.set(wardId, []);
+    }
+
+    const buffer = this.emotionBuffers.get(wardId)!;
+    buffer.push(bufferData);
+
+    this.logger.log(
+      `[EMOTION_BUFFERED] wardId=${wardId} emotion=${payload.emotion} confidence=${payload.confidence.toFixed(2)} bufferSize=${buffer.length}`,
+    );
+
+    return {
+      success: true,
+      alertType: 'emotion',
+      processed: 'buffered',
+    };
+  }
+
+  /**
+   * 10분마다 Emotion 버퍼 플러시 및 집계
+   */
+  @Cron('0 */10 * * * *')
+  async flushEmotionBuffers(): Promise<void> {
+    const startTime = Date.now();
+    const wardIds = Array.from(this.emotionBuffers.keys());
+
+    if (wardIds.length === 0) {
+      return;
+    }
+
+    this.logger.log(
+      `[EMOTION_FLUSH_START] wardCount=${wardIds.length} totalBuffered=${wardIds.reduce((sum, id) => sum + (this.emotionBuffers.get(id)?.length ?? 0), 0)}`,
+    );
+
+    for (const wardId of wardIds) {
+      const buffer = this.emotionBuffers.get(wardId);
+      if (!buffer || buffer.length === 0) continue;
+
+      try {
+        await this.aggregateAndSaveEmotions(wardId, buffer);
+        this.emotionBuffers.set(wardId, []); // 버퍼 클리어
+      } catch (error) {
+        this.logger.error(
+          `[EMOTION_FLUSH_ERROR] wardId=${wardId} error=${error instanceof Error ? error.message : String(error)}`,
+        );
+      }
+    }
+
+    const elapsed = Date.now() - startTime;
+    this.logger.log(`[EMOTION_FLUSH_COMPLETE] elapsed=${elapsed}ms`);
+  }
+
+  /**
+   * Emotion 집계 및 저장
+   */
+  private async aggregateAndSaveEmotions(
+    wardId: string,
+    buffer: EmotionBufferData[],
+  ): Promise<void> {
+    if (buffer.length === 0) return;
+
+    const now = new Date();
+    const periodEnd = new Date(
+      Math.floor(now.getTime() / (10 * 60 * 1000)) * (10 * 60 * 1000),
+    );
+    const periodStart = new Date(periodEnd.getTime() - 10 * 60 * 1000);
+
+    // 감정별 카운트
+    const emotionCounts: Record<EmotionType, number> = {
+      neutral: 0,
+      happy: 0,
+      sad: 0,
+      angry: 0,
+      fearful: 0,
+      disgusted: 0,
+      surprised: 0,
+    };
+
+    let totalConfidence = 0;
+
+    for (const data of buffer) {
+      emotionCounts[data.emotion]++;
+      totalConfidence += data.confidence;
+    }
+
+    const totalSamples = buffer.length;
+
+    // 감정 분포 (비율)
+    const emotionDistribution: Record<EmotionType, number> = {} as Record<
+      EmotionType,
+      number
+    >;
+    for (const [emotion, count] of Object.entries(emotionCounts)) {
+      emotionDistribution[emotion as EmotionType] =
+        Math.round((count / totalSamples) * 1000) / 1000;
+    }
+
+    // 부정적 감정 비율
+    const negativeCount = NEGATIVE_EMOTIONS.reduce(
+      (sum, emotion) => sum + emotionCounts[emotion],
+      0,
+    );
+    const negativeRatio = Math.round((negativeCount / totalSamples) * 1000) / 1000;
+
+    // 평균 confidence
+    const averageConfidence =
+      Math.round((totalConfidence / totalSamples) * 1000) / 1000;
+
+    // 지배적 감정
+    const dominantEmotion = Object.entries(emotionCounts).reduce((a, b) =>
+      a[1] > b[1] ? a : b,
+    )[0] as EmotionType;
+
+    // DB 저장
+    const summary = await this.prisma.emotionSummary.upsert({
+      where: {
+        wardId_periodStart: {
+          wardId,
+          periodStart,
+        },
+      },
+      update: {
+        totalSamples,
+        emotionDistribution,
+        averageConfidence,
+        negativeRatio,
+        dominantEmotion,
+      },
+      create: {
+        wardId,
+        periodStart,
+        periodEnd,
+        totalSamples,
+        emotionDistribution,
+        averageConfidence,
+        negativeRatio,
+        dominantEmotion,
+      },
+    });
+
+    this.logger.log(
+      `[EMOTION_AGGREGATED] wardId=${wardId} period=${periodStart.toISOString()}-${periodEnd.toISOString()} samples=${totalSamples} dominant=${dominantEmotion} negativeRatio=${negativeRatio} summaryId=${summary.id}`,
+    );
+  }
+
+  /**
+   * CareAlertEvent 저장
+   */
+  private async saveCareAlertEvent(
+    wardId: string,
+    dto: CreateCareAlertDto,
+  ): Promise<{
+    id: string;
+    alertType: string;
+    severity: string;
+    timestamp: Date;
+    rawPayload: unknown;
+  }> {
+    // JSON 타입으로 안전하게 변환
+    const rawPayload = JSON.parse(JSON.stringify(dto.data));
+
+    const event = await this.prisma.careAlertEvent.create({
+      data: {
+        wardId,
+        alertType: dto.alertType,
+        severity: dto.severity,
+        timestamp: new Date(dto.timestamp),
+        rawPayload,
+      },
+    });
+
+    this.logger.log(
+      `[CARE_ALERT_SAVED] wardId=${wardId} alertId=${event.id} alertType=${dto.alertType} severity=${dto.severity}`,
+    );
+
+    return event;
+  }
+
+  /**
+   * 즉시 알림 조건 확인
+   */
+  private shouldSendImmediateNotification(
+    alertType: AlertType,
+    severity: Severity,
+  ): boolean {
+    const conditions = IMMEDIATE_ALERT_CONDITIONS[alertType];
+    return conditions.includes(severity);
+  }
+
+  /**
+   * 알림 전송 (APNs + WebSocket)
+   */
+  private async sendNotifications(
+    wardId: string,
+    event: { id: string; alertType: string; severity: string; timestamp: Date },
+  ): Promise<void> {
+    const notifyStart = Date.now();
+
+    // Ward 정보 조회 (Guardian/Organization 관계 포함)
+    const ward = await this.prisma.ward.findUnique({
+      where: { id: wardId },
+      include: {
+        user: true,
+        guardian: {
+          include: {
+            user: {
+              include: {
+                devices: true,
+              },
+            },
+          },
+        },
+        organization: true,
+      },
+    });
+
+    if (!ward) {
+      this.logger.warn(`[NOTIFY_SKIP] wardId=${wardId} reason=ward_not_found`);
+      return;
+    }
+
+    const wardName = ward.user.nickname ?? ward.user.displayName ?? '어르신';
+    const { title, body } = this.getAlertMessage(event.alertType, wardName);
+
+    // 1. Guardian에게 APNs Push
+    if (ward.guardian?.user.devices) {
+      const tokens = ward.guardian.user.devices
+        .filter((d) => d.apnsToken)
+        .map((d) => ({ token: d.apnsToken!, env: d.env }));
+
+      if (tokens.length > 0) {
+        this.logger.log(
+          `[NOTIFY_PUSH] wardId=${wardId} guardianId=${ward.guardian.id} tokens=${tokens.length}`,
+        );
+
+        await this.pushService.sendPush({
+          tokens,
+          type: 'alert',
+          title,
+          body,
+          payload: {
+            type: 'care_alert',
+            alertType: event.alertType,
+            alertId: event.id,
+            wardId,
+            severity: event.severity,
+          },
+          interruptionLevel:
+            event.severity === 'critical' ? 'critical' : 'time-sensitive',
+        });
+      }
+    }
+
+    // 2. Organization에게 WebSocket 이벤트
+    if (ward.organization) {
+      this.logger.log(
+        `[NOTIFY_WS] wardId=${wardId} organizationId=${ward.organization.id}`,
+      );
+
+      this.eventsService.emit({
+        type: 'room-danger',
+        roomName: `org:${ward.organization.id}`,
+        isDanger: true,
+        name: `${event.alertType}:${wardId}`,
+      });
+    }
+
+    const elapsed = Date.now() - notifyStart;
+    this.logger.log(
+      `[NOTIFY_COMPLETE] wardId=${wardId} alertId=${event.id} elapsed=${elapsed}ms`,
+    );
+  }
+
+  /**
+   * 알림 메시지 생성
+   */
+  private getAlertMessage(
+    alertType: string,
+    wardName: string,
+  ): { title: string; body: string } {
+    switch (alertType) {
+      case 'device_fall':
+        return {
+          title: '긴급: 기기 낙상 감지',
+          body: `${wardName}님의 기기 낙상이 감지되었습니다. 확인해주세요.`,
+        };
+      case 'person_fall':
+        return {
+          title: '긴급: 낙상 감지',
+          body: `${wardName}님의 낙상이 감지되었습니다. 확인해주세요.`,
+        };
+      case 'loud_voice':
+        return {
+          title: '주의: 큰 소리 감지',
+          body: `${wardName}님에게서 큰 소리가 감지되었습니다.`,
+        };
+      default:
+        return {
+          title: '케어 알림',
+          body: `${wardName}님의 상태를 확인해주세요.`,
+        };
+    }
+  }
+
+  /**
+   * 알림 목록 조회 (Guardian용)
+   */
+  async getAlerts(
+    wardId: string,
+    options: { type?: string; since?: string; limit?: number },
+  ): Promise<GetAlertsResponse> {
+    this.logger.log(
+      `[GET_ALERTS] wardId=${wardId} type=${options.type ?? 'all'} since=${options.since ?? 'none'}`,
+    );
+
+    const where: {
+      wardId: string;
+      alertType?: string;
+      timestamp?: { gte: Date };
+    } = { wardId };
+
+    if (options.type) {
+      where.alertType = options.type;
+    }
+
+    if (options.since) {
+      where.timestamp = { gte: new Date(options.since) };
+    }
+
+    const [alerts, total] = await Promise.all([
+      this.prisma.careAlertEvent.findMany({
+        where,
+        orderBy: { timestamp: 'desc' },
+        take: options.limit ?? 50,
+      }),
+      this.prisma.careAlertEvent.count({ where }),
+    ]);
+
+    return {
+      alerts: alerts.map((alert) => ({
+        id: alert.id,
+        wardId: alert.wardId,
+        alertType: alert.alertType as AlertType,
+        severity: alert.severity as Severity,
+        timestamp: alert.timestamp.toISOString(),
+        rawPayload: alert.rawPayload as Record<string, unknown>,
+        acknowledged: alert.acknowledged,
+        acknowledgedAt: alert.acknowledgedAt?.toISOString() ?? null,
+        acknowledgedBy: alert.acknowledgedBy ?? null,
+        createdAt: alert.createdAt.toISOString(),
+      })),
+      total,
+    };
+  }
+
+  /**
+   * 감정 리포트 조회 (Guardian용)
+   */
+  async getEmotionReport(wardId: string, date: string): Promise<EmotionReportResponse> {
+    this.logger.log(`[GET_EMOTION_REPORT] wardId=${wardId} date=${date}`);
+
+    const targetDate = new Date(date);
+    const startOfDay = new Date(targetDate.setHours(0, 0, 0, 0));
+    const endOfDay = new Date(targetDate.setHours(23, 59, 59, 999));
+
+    const [summaries, alertCount] = await Promise.all([
+      this.prisma.emotionSummary.findMany({
+        where: {
+          wardId,
+          periodStart: {
+            gte: startOfDay,
+            lte: endOfDay,
+          },
+        },
+        orderBy: { periodStart: 'asc' },
+      }),
+      this.prisma.careAlertEvent.count({
+        where: {
+          wardId,
+          timestamp: {
+            gte: startOfDay,
+            lte: endOfDay,
+          },
+        },
+      }),
+    ]);
+
+    // 일별 통계 계산
+    let totalSamples = 0;
+    let totalNegativeRatio = 0;
+    const emotionTotals: Record<EmotionType, number> = {
+      neutral: 0,
+      happy: 0,
+      sad: 0,
+      angry: 0,
+      fearful: 0,
+      disgusted: 0,
+      surprised: 0,
+    };
+
+    for (const summary of summaries) {
+      totalSamples += summary.totalSamples;
+      totalNegativeRatio += Number(summary.negativeRatio) * summary.totalSamples;
+
+      const dist = summary.emotionDistribution as Record<EmotionType, number>;
+      for (const [emotion, ratio] of Object.entries(dist)) {
+        emotionTotals[emotion as EmotionType] += ratio * summary.totalSamples;
+      }
+    }
+
+    let dominantEmotion: EmotionType | null = null;
+    if (totalSamples > 0) {
+      dominantEmotion = Object.entries(emotionTotals).reduce((a, b) =>
+        a[1] > b[1] ? a : b,
+      )[0] as EmotionType;
+    }
+
+    return {
+      date,
+      summaries: summaries.map((s) => ({
+        id: s.id,
+        periodStart: s.periodStart.toISOString(),
+        periodEnd: s.periodEnd.toISOString(),
+        totalSamples: s.totalSamples,
+        emotionDistribution: s.emotionDistribution as Record<EmotionType, number>,
+        averageConfidence: Number(s.averageConfidence),
+        negativeRatio: Number(s.negativeRatio),
+        dominantEmotion: s.dominantEmotion as EmotionType,
+      })),
+      dailyStats: {
+        totalSamples,
+        dominantEmotion,
+        negativeRatio:
+          totalSamples > 0
+            ? Math.round((totalNegativeRatio / totalSamples) * 1000) / 1000
+            : 0,
+        alertCount,
+      },
+    };
+  }
+
+  /**
+   * 알림 확인 처리
+   */
+  async acknowledgeAlert(
+    alertId: string,
+    userId: string,
+  ): Promise<AcknowledgeAlertResponse> {
+    this.logger.log(`[ACKNOWLEDGE_ALERT] alertId=${alertId} userId=${userId}`);
+
+    const now = new Date();
+
+    await this.prisma.careAlertEvent.update({
+      where: { id: alertId },
+      data: {
+        acknowledged: true,
+        acknowledgedAt: now,
+        acknowledgedBy: userId,
+      },
+    });
+
+    return {
+      success: true,
+      alertId,
+      acknowledgedAt: now.toISOString(),
+    };
+  }
+
+  /**
+   * 특정 Ward의 버퍼 상태 조회 (디버깅용)
+   */
+  getBufferStatus(wardId?: string): {
+    wardId: string;
+    bufferSize: number;
+    oldestTimestamp?: number;
+    newestTimestamp?: number;
+  }[] {
+    const result: {
+      wardId: string;
+      bufferSize: number;
+      oldestTimestamp?: number;
+      newestTimestamp?: number;
+    }[] = [];
+
+    const wards = wardId ? [wardId] : Array.from(this.emotionBuffers.keys());
+
+    for (const id of wards) {
+      const buffer = this.emotionBuffers.get(id);
+      if (buffer && buffer.length > 0) {
+        result.push({
+          wardId: id,
+          bufferSize: buffer.length,
+          oldestTimestamp: buffer[0].timestamp,
+          newestTimestamp: buffer[buffer.length - 1].timestamp,
+        });
+      }
+    }
+
+    return result;
+  }
+}

--- a/src/care-alerts/dto/care-alert-response.dto.ts
+++ b/src/care-alerts/dto/care-alert-response.dto.ts
@@ -1,0 +1,58 @@
+import { AlertType, Severity, EmotionType } from '../types/care-alert.types';
+
+// 알림 생성 응답
+export interface CareAlertCreatedResponse {
+  success: boolean;
+  alertType: AlertType;
+  processed: 'buffered' | 'stored';
+  alertId?: string;
+}
+
+// 알림 목록 조회 응답
+export interface CareAlertEventResponse {
+  id: string;
+  wardId: string;
+  alertType: AlertType;
+  severity: Severity;
+  timestamp: string;
+  rawPayload: Record<string, unknown>;
+  acknowledged: boolean;
+  acknowledgedAt: string | null;
+  acknowledgedBy: string | null;
+  createdAt: string;
+}
+
+export interface GetAlertsResponse {
+  alerts: CareAlertEventResponse[];
+  total: number;
+}
+
+// 감정 리포트 응답
+export interface EmotionSummaryResponse {
+  id: string;
+  periodStart: string;
+  periodEnd: string;
+  totalSamples: number;
+  emotionDistribution: Record<EmotionType, number>;
+  averageConfidence: number;
+  negativeRatio: number;
+  dominantEmotion: EmotionType;
+}
+
+export interface EmotionReportResponse {
+  date: string;
+  summaries: EmotionSummaryResponse[];
+  dailyStats: {
+    totalSamples: number;
+    dominantEmotion: EmotionType | null;
+    negativeRatio: number;
+    alertCount: number;
+  };
+}
+
+// 알림 확인 응답
+export interface AcknowledgeAlertResponse {
+  success: boolean;
+  alertId: string;
+  acknowledgedAt: string;
+}

--- a/src/care-alerts/dto/create-care-alert.dto.ts
+++ b/src/care-alerts/dto/create-care-alert.dto.ts
@@ -1,0 +1,32 @@
+import {
+  IsNumber,
+  IsString,
+  IsIn,
+  IsObject,
+  ValidateNested,
+} from 'class-validator';
+import { Type } from 'class-transformer';
+
+class CareAlertDataDto {
+  @IsString()
+  type: string;
+
+  @IsObject()
+  payload: Record<string, unknown>;
+}
+
+export class CreateCareAlertDto {
+  @IsNumber()
+  timestamp: number;
+
+  @IsIn(['emotion', 'device_fall', 'person_fall', 'loud_voice'])
+  alertType: 'emotion' | 'device_fall' | 'person_fall' | 'loud_voice';
+
+  @IsIn(['low', 'medium', 'high', 'critical'])
+  severity: 'low' | 'medium' | 'high' | 'critical';
+
+  @IsObject()
+  @ValidateNested()
+  @Type(() => CareAlertDataDto)
+  data: CareAlertDataDto;
+}

--- a/src/care-alerts/index.ts
+++ b/src/care-alerts/index.ts
@@ -1,0 +1,6 @@
+export * from './care-alerts.module';
+export * from './care-alerts.service';
+export * from './care-alerts.controller';
+export * from './types/care-alert.types';
+export * from './dto/create-care-alert.dto';
+export * from './dto/care-alert-response.dto';

--- a/src/care-alerts/types/care-alert.types.ts
+++ b/src/care-alerts/types/care-alert.types.ts
@@ -1,0 +1,106 @@
+/**
+ * Care Alert Types
+ * iOS 앱에서 전송되는 케어 알림 타입 정의
+ */
+
+export type AlertType = 'emotion' | 'device_fall' | 'person_fall' | 'loud_voice';
+export type Severity = 'low' | 'medium' | 'high' | 'critical';
+export type EmotionType =
+  | 'neutral'
+  | 'happy'
+  | 'sad'
+  | 'angry'
+  | 'fearful'
+  | 'disgusted'
+  | 'surprised';
+
+export type FallType =
+  | 'freefall_impact'
+  | 'impact'
+  | 'rotation_impact'
+  | 'combination';
+
+export type PersonFallDetectionType =
+  | 'rapid_descent'
+  | 'face_disappeared'
+  | 'size_change';
+
+export type LoudVoiceCause = 'scream' | 'loud_speech' | 'unknown';
+
+// Emotion 페이로드
+export interface EmotionPayload {
+  emotion: EmotionType;
+  confidence: number;
+  intensity?: number;
+  previousEmotion?: EmotionType;
+  analysisInterval: number;
+}
+
+// Device Fall 페이로드
+export interface DeviceFallPayload {
+  impactMagnitude: number;
+  fallType: FallType;
+  freefallDuration?: number;
+  maxRotationRate?: number;
+}
+
+// Person Fall 페이로드
+export interface PersonFallPayload {
+  detectionType: PersonFallDetectionType;
+  faceYDelta?: number;
+  deltaTime?: number;
+  lastFacePosition?: {
+    x: number;
+    y: number;
+  };
+}
+
+// Loud Voice 페이로드
+export interface LoudVoicePayload {
+  level: number;
+  decibel: number;
+  duration: number;
+  possibleCause?: LoudVoiceCause;
+}
+
+// 공통 Wrapper
+export interface CareAlertPayload {
+  timestamp: number; // Unix milliseconds
+  alertType: AlertType;
+  severity: Severity;
+  data: {
+    type: string;
+    payload: EmotionPayload | DeviceFallPayload | PersonFallPayload | LoudVoicePayload;
+  };
+}
+
+// Emotion 버퍼 데이터 (집계용)
+export interface EmotionBufferData {
+  timestamp: number;
+  emotion: EmotionType;
+  confidence: number;
+  intensity?: number;
+}
+
+// Emotion 집계 결과
+export interface EmotionAggregation {
+  wardId: string;
+  periodStart: Date;
+  periodEnd: Date;
+  totalSamples: number;
+  emotionDistribution: Record<EmotionType, number>;
+  averageConfidence: number;
+  negativeRatio: number;
+  dominantEmotion: EmotionType;
+}
+
+// 즉시 알림 조건
+export const IMMEDIATE_ALERT_CONDITIONS: Record<AlertType, Severity[]> = {
+  emotion: [], // 즉시 알림 안함
+  device_fall: ['critical', 'high'],
+  person_fall: ['critical'],
+  loud_voice: ['critical', 'high'],
+};
+
+// 부정적 감정 목록
+export const NEGATIVE_EMOTIONS: EmotionType[] = ['sad', 'angry', 'fearful', 'disgusted'];

--- a/src/database/db.service.ts
+++ b/src/database/db.service.ts
@@ -128,7 +128,10 @@ export class DbService implements OnModuleDestroy {
     supportsCallKit?: boolean;
   }) {
     // 익명 사용자 생성 차단 - 기존 사용자만 허용
-    const user = await this.findUserByIdentity(params.identity);
+    // 카카오 JWT는 userId를, API 토큰은 identity를 전달하므로 둘 다 검색
+    const user =
+      (await this.findUserById(params.identity)) ??
+      (await this.findUserByIdentity(params.identity));
     if (!user) {
       throw new Error('로그인이 필요합니다');
     }
@@ -286,16 +289,54 @@ export class DbService implements OnModuleDestroy {
     return this.guardians.getWards(guardianId);
   }
 
+  /**
+   * 보호자의 미연동 어르신들을 이메일로 찾아서 연동
+   * @returns 연동된 수
+   */
+  async linkPendingWardsForGuardian(guardianId: string): Promise<number> {
+    // 1. linked_ward_id가 NULL인 registrations 조회
+    const pendingRegistrations =
+      await this.guardians.findPendingRegistrations(guardianId);
+
+    let linkedCount = 0;
+    for (const reg of pendingRegistrations) {
+      // 2. ward_email로 ward 사용자 찾기
+      const wardUser = await this.users.findByEmail(reg.ward_email);
+      if (!wardUser || wardUser.user_type !== 'ward') continue;
+
+      // 3. ward 테이블에서 ward_id 찾기
+      const ward = await this.wards.findByUserId(wardUser.id);
+      if (!ward) continue;
+
+      // 4. linked_ward_id 업데이트
+      await this.guardians.updateRegistrationLinkedWard(reg.id, ward.id);
+      linkedCount++;
+    }
+
+    return linkedCount;
+  }
+
   async createGuardianWardRegistration(params: {
     guardianId: string;
     wardEmail: string;
     wardPhoneNumber: string;
+    wardName?: string;
+    relation?: string;
+    birthDate?: string;
+    gender?: string;
+    address?: string;
+    medicalConditions?: string;
+    medications?: string;
   }) {
     return this.guardians.createWardRegistration(params);
   }
 
   async findGuardianWardRegistration(id: string, guardianId: string) {
     return this.guardians.findWardRegistration(id, guardianId);
+  }
+
+  async findFirstGuardianWardRegistration(guardianId: string) {
+    return this.guardians.findFirstWardRegistration(guardianId);
   }
 
   async updateGuardianWardRegistration(params: {
@@ -309,14 +350,6 @@ export class DbService implements OnModuleDestroy {
 
   async deleteGuardianWardRegistration(id: string, guardianId: string) {
     return this.guardians.deleteWardRegistration(id, guardianId);
-  }
-
-  async updateGuardianPrimaryWard(params: {
-    guardianId: string;
-    wardEmail: string;
-    wardPhoneNumber: string;
-  }) {
-    return this.guardians.updatePrimaryWard(params);
   }
 
   async unlinkPrimaryWard(guardianId: string) {
@@ -354,6 +387,34 @@ export class DbService implements OnModuleDestroy {
   }
 
   // ============================================================
+  // Call Schedule Group methods
+  // ============================================================
+  async getCallScheduleGroups(guardianId: string) {
+    return this.guardians.getCallScheduleGroups(guardianId);
+  }
+
+  async createCallScheduleGroups(
+    registrationId: string | null,
+    wardId: string | null,
+    items: Array<{
+      id?: string;
+      time: string;
+      weekdays: number[];
+      isEnabled: boolean;
+    }>,
+  ) {
+    return this.guardians.createCallScheduleGroups(registrationId, wardId, items);
+  }
+
+  async deleteCallScheduleGroupsByGuardian(guardianId: string) {
+    return this.guardians.deleteCallScheduleGroupsByGuardian(guardianId);
+  }
+
+  async deleteCallScheduleGroup(scheduleId: string, guardianId: string) {
+    return this.guardians.deleteCallScheduleGroup(scheduleId, guardianId);
+  }
+
+  // ============================================================
   // Ward methods
   // ============================================================
   async createWard(params: {
@@ -376,16 +437,16 @@ export class DbService implements OnModuleDestroy {
     return this.wards.findByGuardianId(guardianId);
   }
 
-  async getWardCallStats(wardId: string) {
-    return this.wards.getCallStats(wardId);
+  async getWardCallStats(wardId: string, days?: number) {
+    return this.wards.getCallStats(wardId, days);
   }
 
   async getWardWeeklyCallChange(wardId: string) {
     return this.wards.getWeeklyCallChange(wardId);
   }
 
-  async getWardMoodStats(wardId: string) {
-    return this.wards.getMoodStats(wardId);
+  async getWardMoodStats(wardId: string, days?: number) {
+    return this.wards.getMoodStats(wardId, days);
   }
 
   async getEmotionTrend(wardId: string, days: number) {
@@ -474,6 +535,10 @@ export class DbService implements OnModuleDestroy {
 
   async markReminderSent(scheduleId: string) {
     return this.wards.markReminderSent(scheduleId);
+  }
+
+  async getSchedulesForCurrentTime(dayOfWeek: number, time: string) {
+    return this.wards.getSchedulesForCurrentTime(dayOfWeek, time);
   }
 
   async listOrganizationBeneficiaries(params: {
@@ -914,14 +979,38 @@ export class DbService implements OnModuleDestroy {
 
   /**
    * 보호자 등록 트랜잭션
-   * 사용자 타입 변경 → 보호자 정보 생성을 원자적으로 처리
+   * 사용자 타입 변경 → 보호자 정보 생성 → 어르신 등록 정보 생성을 원자적으로 처리
    */
   async registerGuardianWithTransaction(params: {
     userId: string;
     wardEmail: string;
     wardPhoneNumber: string;
+    wardBasicInfo?: {
+      name?: string;
+      relation?: string;
+      phoneNumber?: string;
+      birthDate?: string;
+      gender?: string;
+      address?: string;
+    };
+    aiCareInfo?: {
+      medicalConditions?: string;
+      medications?: string;
+    };
+    callSchedule?: {
+      isEnabled: boolean;
+      items: Array<{
+        id?: string;
+        time: string;
+        weekdays: number[];
+        isEnabled: boolean;
+      }>;
+    };
   }): Promise<{
     guardian: {
+      id: string;
+    };
+    registration: {
       id: string;
       ward_email: string;
       ward_phone_number: string;
@@ -937,20 +1026,50 @@ export class DbService implements OnModuleDestroy {
         },
       });
 
-      // 2. 보호자 정보 생성
+      // 2. 보호자 정보 생성 (wardEmail, wardPhoneNumber 제거됨)
       const guardian = await tx.guardian.create({
         data: {
           userId: params.userId,
-          wardEmail: params.wardEmail,
-          wardPhoneNumber: params.wardPhoneNumber,
         },
       });
+
+      // 3. 어르신 등록 정보 생성 (GuardianWardRegistration)
+      const registration = await tx.guardianWardRegistration.create({
+        data: {
+          guardianId: guardian.id,
+          wardEmail: params.wardEmail,
+          wardPhoneNumber: params.wardPhoneNumber,
+          wardName: params.wardBasicInfo?.name,
+          relation: params.wardBasicInfo?.relation,
+          birthDate: params.wardBasicInfo?.birthDate,
+          gender: params.wardBasicInfo?.gender,
+          address: params.wardBasicInfo?.address,
+          medicalConditions: params.aiCareInfo?.medicalConditions,
+          medications: params.aiCareInfo?.medications,
+        },
+      });
+
+      // 4. 스케줄 생성 (callSchedule이 있고 enabled인 경우)
+      if (params.callSchedule?.isEnabled && params.callSchedule.items.length > 0) {
+        await tx.callScheduleGroup.createMany({
+          data: params.callSchedule.items.map(item => ({
+            registrationId: registration.id,
+            wardId: null,
+            time: item.time,
+            weekdays: item.weekdays,
+            isEnabled: item.isEnabled,
+          })),
+        });
+      }
 
       return {
         guardian: {
           id: guardian.id,
-          ward_email: guardian.wardEmail,
-          ward_phone_number: guardian.wardPhoneNumber,
+        },
+        registration: {
+          id: registration.id,
+          ward_email: registration.wardEmail,
+          ward_phone_number: registration.wardPhoneNumber,
         },
       };
     });

--- a/src/database/prisma-mappers.ts
+++ b/src/database/prisma-mappers.ts
@@ -11,6 +11,8 @@ import {
   CallSummary,
   Ward,
   GuardianWardRegistration,
+  CareAlertEvent,
+  EmotionSummary,
 } from '@prisma/client';
 
 import {
@@ -23,6 +25,8 @@ import {
   RoomMemberRow,
   WardRow,
   GuardianWardRegistrationRow,
+  CareAlertEventRow,
+  EmotionSummaryRow,
 } from './types';
 
 export function toUserRow(user: User): UserRow {
@@ -67,8 +71,6 @@ export function toGuardianRow(guardian: Guardian): GuardianRow {
   return {
     id: guardian.id,
     user_id: guardian.userId,
-    ward_email: guardian.wardEmail,
-    ward_phone_number: guardian.wardPhoneNumber,
     created_at: guardian.createdAt.toISOString(),
     updated_at: guardian.updatedAt.toISOString(),
   };
@@ -139,5 +141,35 @@ export function toGuardianWardRegistrationRow(
     linked_ward_id: reg.linkedWardId,
     created_at: reg.createdAt.toISOString(),
     updated_at: reg.updatedAt.toISOString(),
+  };
+}
+
+export function toCareAlertEventRow(event: CareAlertEvent): CareAlertEventRow {
+  return {
+    id: event.id,
+    ward_id: event.wardId,
+    alert_type: event.alertType,
+    severity: event.severity,
+    timestamp: event.timestamp.toISOString(),
+    raw_payload: event.rawPayload as Record<string, unknown>,
+    acknowledged: event.acknowledged,
+    acknowledged_at: event.acknowledgedAt?.toISOString() ?? null,
+    acknowledged_by: event.acknowledgedBy ?? null,
+    created_at: event.createdAt.toISOString(),
+  };
+}
+
+export function toEmotionSummaryRow(summary: EmotionSummary): EmotionSummaryRow {
+  return {
+    id: summary.id,
+    ward_id: summary.wardId,
+    period_start: summary.periodStart.toISOString(),
+    period_end: summary.periodEnd.toISOString(),
+    total_samples: summary.totalSamples,
+    emotion_distribution: summary.emotionDistribution as Record<string, number>,
+    average_confidence: Number(summary.averageConfidence),
+    negative_ratio: Number(summary.negativeRatio),
+    dominant_emotion: summary.dominantEmotion,
+    created_at: summary.createdAt.toISOString(),
   };
 }

--- a/src/database/repositories/guardian.repository.ts
+++ b/src/database/repositories/guardian.repository.ts
@@ -16,14 +16,10 @@ export class GuardianRepository {
 
   async create(params: {
     userId: string;
-    wardEmail: string;
-    wardPhoneNumber: string;
   }): Promise<GuardianRow> {
     const guardian = await this.prisma.guardian.create({
       data: {
         userId: params.userId,
-        wardEmail: params.wardEmail,
-        wardPhoneNumber: params.wardPhoneNumber,
       },
     });
     return toGuardianRow(guardian);
@@ -62,34 +58,31 @@ export class GuardianRepository {
     };
   }
 
-  async findByWardEmail(wardEmail: string): Promise<GuardianRow | undefined> {
+  async findByWardEmail(wardEmail: string): Promise<
+    | (GuardianRow & {
+        registration_id: string;
+        ward_email: string;
+        ward_phone_number: string;
+      })
+    | undefined
+  > {
     const normalizedEmail = wardEmail.toLowerCase().trim();
-    const guardian = await this.prisma.guardian.findFirst({
+    // GuardianWardRegistration에서 wardEmail로 조회
+    const registration = await this.prisma.guardianWardRegistration.findFirst({
       where: { wardEmail: { equals: normalizedEmail, mode: 'insensitive' } },
+      include: { guardian: true },
     });
-    return guardian ? toGuardianRow(guardian) : undefined;
+    if (!registration?.guardian) return undefined;
+    return {
+      ...toGuardianRow(registration.guardian),
+      registration_id: registration.id,
+      ward_email: registration.wardEmail,
+      ward_phone_number: registration.wardPhoneNumber,
+    };
   }
 
   async getWards(guardianId: string) {
-    // Primary ward from guardians table
-    const guardian = await this.prisma.guardian.findUnique({
-      where: { id: guardianId },
-      include: {
-        wards: {
-          include: {
-            user: {
-              select: {
-                id: true,
-                nickname: true,
-                profileImageUrl: true,
-              },
-            },
-          },
-        },
-      },
-    });
-
-    // Additional registrations
+    // 모든 어르신 등록 정보는 GuardianWardRegistration에서 관리
     const registrations = await this.prisma.guardianWardRegistration.findMany({
       where: { guardianId },
       include: {
@@ -105,13 +98,11 @@ export class GuardianRepository {
           },
         },
       },
+      orderBy: { createdAt: 'asc' },
     });
 
     // Collect all ward userIds for batch query
     const wardUserIds: string[] = [];
-    if (guardian?.wards[0]?.userId) {
-      wardUserIds.push(guardian.wards[0].userId);
-    }
     for (const reg of registrations) {
       if (reg.linkedWard?.userId) {
         wardUserIds.push(reg.linkedWard.userId);
@@ -143,28 +134,9 @@ export class GuardianRepository {
       last_call_at: string | null;
     }> = [];
 
-    // Add primary ward
-    if (guardian) {
-      const primaryWard = guardian.wards[0];
-      const lastCallAt = primaryWard?.userId
-        ? (lastCallMap.get(primaryWard.userId)?.toISOString() ?? null)
-        : null;
-
-      results.push({
-        id: guardian.id,
-        ward_email: guardian.wardEmail,
-        ward_phone_number: guardian.wardPhoneNumber,
-        is_primary: true,
-        linked_ward_id: primaryWard?.id ?? null,
-        ward_user_id: primaryWard?.userId ?? null,
-        ward_nickname: primaryWard?.user.nickname ?? null,
-        ward_profile_image_url: primaryWard?.user.profileImageUrl ?? null,
-        last_call_at: lastCallAt,
-      });
-    }
-
-    // Add additional registrations
-    for (const reg of registrations) {
+    // 첫 번째 등록을 primary로 표시
+    for (let i = 0; i < registrations.length; i++) {
+      const reg = registrations[i];
       const lastCallAt = reg.linkedWard?.userId
         ? (lastCallMap.get(reg.linkedWard.userId)?.toISOString() ?? null)
         : null;
@@ -173,7 +145,7 @@ export class GuardianRepository {
         id: reg.id,
         ward_email: reg.wardEmail,
         ward_phone_number: reg.wardPhoneNumber,
-        is_primary: false,
+        is_primary: i === 0, // 첫 번째 등록이 primary
         linked_ward_id: reg.linkedWardId,
         ward_user_id: reg.linkedWard?.userId ?? null,
         ward_nickname: reg.linkedWard?.user.nickname ?? null,
@@ -189,15 +161,41 @@ export class GuardianRepository {
     guardianId: string;
     wardEmail: string;
     wardPhoneNumber: string;
+    wardName?: string;
+    relation?: string;
+    birthDate?: string;
+    gender?: string;
+    address?: string;
+    medicalConditions?: string;
+    medications?: string;
   }): Promise<GuardianWardRegistrationRow> {
     const registration = await this.prisma.guardianWardRegistration.create({
       data: {
         guardianId: params.guardianId,
         wardEmail: params.wardEmail,
         wardPhoneNumber: params.wardPhoneNumber,
+        wardName: params.wardName,
+        relation: params.relation,
+        birthDate: params.birthDate,
+        gender: params.gender,
+        address: params.address,
+        medicalConditions: params.medicalConditions,
+        medications: params.medications,
       },
     });
     return toGuardianWardRegistrationRow(registration);
+  }
+
+  async findFirstWardRegistration(
+    guardianId: string,
+  ): Promise<GuardianWardRegistrationRow | undefined> {
+    const registration = await this.prisma.guardianWardRegistration.findFirst({
+      where: { guardianId },
+      orderBy: { createdAt: 'asc' },
+    });
+    return registration
+      ? toGuardianWardRegistrationRow(registration)
+      : undefined;
   }
 
   async findWardRegistration(
@@ -262,25 +260,6 @@ export class GuardianRepository {
       });
       return result.count > 0;
     });
-  }
-
-  async updatePrimaryWard(params: {
-    guardianId: string;
-    wardEmail: string;
-    wardPhoneNumber: string;
-  }): Promise<GuardianRow | undefined> {
-    try {
-      const guardian = await this.prisma.guardian.update({
-        where: { id: params.guardianId },
-        data: {
-          wardEmail: params.wardEmail,
-          wardPhoneNumber: params.wardPhoneNumber,
-        },
-      });
-      return toGuardianRow(guardian);
-    } catch {
-      return undefined;
-    }
   }
 
   async unlinkPrimaryWard(guardianId: string): Promise<void> {
@@ -378,5 +357,159 @@ export class GuardianRepository {
       call_complete: settings.callComplete,
       health_alert: settings.healthAlert,
     };
+  }
+
+  // ===== Call Schedule Group Methods =====
+
+  async getCallScheduleGroups(guardianId: string) {
+    // 1. Get linked ward
+    const linkedWard = await this.prisma.ward.findFirst({
+      where: { guardianId },
+    });
+
+    // 2. Get registrations
+    const registrations = await this.prisma.guardianWardRegistration.findMany({
+      where: { guardianId },
+      select: { id: true },
+    });
+    const registrationIds = registrations.map(r => r.id);
+
+    // 3. Get schedules for ward or registrations
+    const schedules = await this.prisma.callScheduleGroup.findMany({
+      where: {
+        OR: [
+          ...(linkedWard ? [{ wardId: linkedWard.id }] : []),
+          ...(registrationIds.length > 0
+            ? [{ registrationId: { in: registrationIds } }]
+            : []),
+        ],
+      },
+      orderBy: { createdAt: 'asc' },
+    });
+
+    return schedules.map(s => ({
+      id: s.id,
+      registration_id: s.registrationId,
+      ward_id: s.wardId,
+      time: s.time,
+      weekdays: s.weekdays,
+      is_enabled: s.isEnabled,
+      created_at: s.createdAt,
+      updated_at: s.updatedAt,
+    }));
+  }
+
+  async createCallScheduleGroups(
+    registrationId: string | null,
+    wardId: string | null,
+    items: Array<{
+      id?: string;
+      time: string;
+      weekdays: number[];
+      isEnabled: boolean;
+    }>,
+  ) {
+    const data = items.map(item => ({
+      registrationId,
+      wardId,
+      time: item.time,
+      weekdays: item.weekdays,
+      isEnabled: item.isEnabled,
+    }));
+
+    await this.prisma.callScheduleGroup.createMany({ data });
+  }
+
+  async deleteCallScheduleGroupsByGuardian(guardianId: string) {
+    // 1. Get linked ward
+    const linkedWard = await this.prisma.ward.findFirst({
+      where: { guardianId },
+    });
+
+    // 2. Get registrations
+    const registrations = await this.prisma.guardianWardRegistration.findMany({
+      where: { guardianId },
+      select: { id: true },
+    });
+    const registrationIds = registrations.map(r => r.id);
+
+    // 3. Delete schedules
+    await this.prisma.callScheduleGroup.deleteMany({
+      where: {
+        OR: [
+          ...(linkedWard ? [{ wardId: linkedWard.id }] : []),
+          ...(registrationIds.length > 0
+            ? [{ registrationId: { in: registrationIds } }]
+            : []),
+        ],
+      },
+    });
+  }
+
+  async deleteCallScheduleGroup(
+    scheduleId: string,
+    guardianId: string,
+  ): Promise<boolean> {
+    // Verify ownership first
+    const linkedWard = await this.prisma.ward.findFirst({
+      where: { guardianId },
+    });
+
+    const registrations = await this.prisma.guardianWardRegistration.findMany({
+      where: { guardianId },
+      select: { id: true },
+    });
+    const registrationIds = registrations.map(r => r.id);
+
+    const schedule = await this.prisma.callScheduleGroup.findFirst({
+      where: {
+        id: scheduleId,
+        OR: [
+          ...(linkedWard ? [{ wardId: linkedWard.id }] : []),
+          ...(registrationIds.length > 0
+            ? [{ registrationId: { in: registrationIds } }]
+            : []),
+        ],
+      },
+    });
+
+    if (!schedule) return false;
+
+    await this.prisma.callScheduleGroup.delete({
+      where: { id: scheduleId },
+    });
+
+    return true;
+  }
+
+  // ===== Ward Linking Methods =====
+
+  async findPendingRegistrations(
+    guardianId: string,
+  ): Promise<Array<{ id: string; ward_email: string }>> {
+    const registrations = await this.prisma.guardianWardRegistration.findMany({
+      where: {
+        guardianId,
+        linkedWardId: null,
+      },
+      select: {
+        id: true,
+        wardEmail: true,
+      },
+    });
+    return registrations.map((r) => ({
+      id: r.id,
+      ward_email: r.wardEmail,
+    }));
+  }
+
+  async updateRegistrationLinkedWard(
+    registrationId: string,
+    wardId: string,
+  ): Promise<void> {
+    await this.prisma.guardianWardRegistration.update({
+      where: { id: registrationId },
+      data: { linkedWardId: wardId },
+    });
   }
 }

--- a/src/database/repositories/ward.repository.ts
+++ b/src/database/repositories/ward.repository.ts
@@ -166,18 +166,21 @@ export class WardRepository {
     };
   }
 
-  async getCallStats(wardId: string) {
+  async getCallStats(wardId: string, days?: number) {
     const ward = await this.prisma.ward.findUnique({
       where: { id: wardId },
       select: { userId: true },
     });
     if (!ward) return { totalCalls: 0, avgDuration: 0 };
 
+    const cutoff = days ? new Date(Date.now() - days * 24 * 60 * 60 * 1000) : undefined;
+
     const calls = await this.prisma.call.findMany({
       where: {
         calleeUserId: ward.userId,
         state: 'ended',
         answeredAt: { not: null },
+        ...(cutoff && { createdAt: { gte: cutoff } }),
       },
       select: {
         answeredAt: true,
@@ -229,10 +232,16 @@ export class WardRepository {
     return thisWeek - lastWeek;
   }
 
-  async getMoodStats(wardId: string) {
+  async getMoodStats(wardId: string, days?: number) {
+    const cutoff = days ? new Date(Date.now() - days * 24 * 60 * 60 * 1000) : undefined;
+
     const summaries = await this.prisma.callSummary.groupBy({
       by: ['mood'],
-      where: { wardId, mood: { not: null } },
+      where: {
+        wardId,
+        mood: { not: null },
+        ...(cutoff && { createdAt: { gte: cutoff } }),
+      },
       _count: true,
     });
 
@@ -837,6 +846,38 @@ export class WardRepository {
       where: { id: scheduleId },
       data: { reminderSentAt: new Date() },
     });
+  }
+
+  /**
+   * 현재 시간에 해당하는 스케줄 조회 (call_schedule_groups 테이블)
+   * 자동 전화 발신용
+   */
+  async getSchedulesForCurrentTime(dayOfWeek: number, time: string) {
+    const schedules = await this.prisma.callScheduleGroup.findMany({
+      where: {
+        time,
+        weekdays: { has: dayOfWeek },
+        isEnabled: true,
+        wardId: { not: null },
+      },
+      include: {
+        ward: {
+          include: {
+            user: { select: { id: true, identity: true } },
+          },
+        },
+      },
+    });
+
+    return schedules
+      .filter(s => s.ward !== null)
+      .map(s => ({
+        schedule_id: s.id,
+        ward_id: s.wardId!,
+        ward_user_id: s.ward!.userId,
+        ward_identity: s.ward!.user.identity,
+        ai_persona: s.ward!.aiPersona ?? '다미',
+      }));
   }
 
   async listOrganizationBeneficiaries(params: {

--- a/src/database/types.ts
+++ b/src/database/types.ts
@@ -21,8 +21,6 @@ export type UserRow = {
 export type GuardianRow = {
   id: string;
   user_id: string;
-  ward_email: string;
-  ward_phone_number: string;
   created_at: string;
   updated_at: string;
 };
@@ -218,5 +216,31 @@ export type HealthAlertRow = {
   message: string;
   call_summary_id: string | null;
   is_read: boolean;
+  created_at: string;
+};
+
+export type CareAlertEventRow = {
+  id: string;
+  ward_id: string;
+  alert_type: string;
+  severity: string;
+  timestamp: string;
+  raw_payload: Record<string, unknown>;
+  acknowledged: boolean;
+  acknowledged_at: string | null;
+  acknowledged_by: string | null;
+  created_at: string;
+};
+
+export type EmotionSummaryRow = {
+  id: string;
+  ward_id: string;
+  period_start: string;
+  period_end: string;
+  total_samples: number;
+  emotion_distribution: Record<string, number>;
+  average_confidence: number;
+  negative_ratio: number;
+  dominant_emotion: string;
   created_at: string;
 };

--- a/src/guardians/guardians.controller.ts
+++ b/src/guardians/guardians.controller.ts
@@ -51,11 +51,15 @@ export class GuardiansController {
   @Get('dashboard')
   async getDashboard(
     @Headers('authorization') authorization: string | undefined,
+    @Query('period') period?: string,
   ) {
     const payload = this.verifyAuthHeader(authorization);
+    const dashboardPeriod = ['today', 'week', 'month'].includes(period ?? '')
+      ? (period as 'today' | 'week' | 'month')
+      : undefined;
 
     try {
-      return await this.guardiansService.getDashboard(payload.sub);
+      return await this.guardiansService.getDashboard(payload.sub, dashboardPeriod);
     } catch (error) {
       if ((error as HttpException).getStatus?.()) {
         throw error;
@@ -111,7 +115,32 @@ export class GuardiansController {
   @Post('wards')
   async addWard(
     @Headers('authorization') authorization: string | undefined,
-    @Body() body: { wardEmail?: string; wardPhoneNumber?: string },
+    @Body()
+    body: {
+      wardEmail?: string;
+      wardPhoneNumber?: string;
+      wardBasicInfo?: {
+        name?: string;
+        relation?: string;
+        phoneNumber?: string;
+        birthDate?: string;
+        gender?: string;
+        address?: string;
+      };
+      aiCareInfo?: {
+        medicalConditions?: string;
+        medications?: string;
+      };
+      callSchedule?: {
+        isEnabled: boolean;
+        items: Array<{
+          id?: string;
+          time: string;
+          weekdays: number[];
+          isEnabled: boolean;
+        }>;
+      };
+    },
   ) {
     const payload = this.verifyAuthHeader(authorization);
 
@@ -142,6 +171,11 @@ export class GuardiansController {
         payload.sub,
         wardEmail,
         wardPhoneNumber,
+        {
+          wardBasicInfo: body.wardBasicInfo,
+          aiCareInfo: body.aiCareInfo,
+          callSchedule: body.callSchedule,
+        },
       );
     } catch (error) {
       if ((error as HttpException).getStatus?.()) {
@@ -278,6 +312,82 @@ export class GuardiansController {
       );
       throw new HttpException(
         'Failed to update notification settings',
+        HttpStatus.INTERNAL_SERVER_ERROR,
+      );
+    }
+  }
+
+  @Get('schedules')
+  async getSchedules(
+    @Headers('authorization') authorization: string | undefined,
+  ) {
+    const payload = this.verifyAuthHeader(authorization);
+
+    try {
+      return await this.guardiansService.getSchedules(payload.sub);
+    } catch (error) {
+      if ((error as HttpException).getStatus?.()) {
+        throw error;
+      }
+      this.logger.warn(`getSchedules failed error=${(error as Error).message}`);
+      throw new HttpException(
+        'Failed to get schedules',
+        HttpStatus.INTERNAL_SERVER_ERROR,
+      );
+    }
+  }
+
+  @Put('schedules')
+  async updateSchedules(
+    @Headers('authorization') authorization: string | undefined,
+    @Body()
+    body: {
+      isEnabled: boolean;
+      items: Array<{
+        id?: string;
+        time: string;
+        weekdays: number[];
+        isEnabled: boolean;
+      }>;
+    },
+  ) {
+    const payload = this.verifyAuthHeader(authorization);
+
+    try {
+      return await this.guardiansService.updateSchedules(payload.sub, body);
+    } catch (error) {
+      if ((error as HttpException).getStatus?.()) {
+        throw error;
+      }
+      this.logger.warn(
+        `updateSchedules failed error=${(error as Error).message}`,
+      );
+      throw new HttpException(
+        'Failed to update schedules',
+        HttpStatus.INTERNAL_SERVER_ERROR,
+      );
+    }
+  }
+
+  @Delete('schedules/:scheduleId')
+  async deleteSchedule(
+    @Headers('authorization') authorization: string | undefined,
+    @Param('scheduleId') scheduleId: string,
+  ) {
+    const payload = this.verifyAuthHeader(authorization);
+
+    try {
+      await this.guardiansService.deleteSchedule(payload.sub, scheduleId);
+      return { success: true, message: '스케줄이 삭제되었습니다.' };
+    } catch (error) {
+      if ((error as HttpException).getStatus?.()) {
+        throw error;
+      }
+      this.logger.warn(
+        `deleteSchedule failed error=${(error as Error).message}`,
+      );
+      throw new HttpException(
+        'Failed to delete schedule',
         HttpStatus.INTERNAL_SERVER_ERROR,
       );
     }

--- a/src/guardians/guardians.service.ts
+++ b/src/guardians/guardians.service.ts
@@ -21,7 +21,7 @@ export class GuardiansService {
     return { user, guardian };
   }
 
-  async getDashboard(userId: string) {
+  async getDashboard(userId: string, period?: 'today' | 'week' | 'month') {
     const { guardian } = await this.verifyGuardianAccess(userId);
     const linkedWard = await this.dbService.findWardByGuardianId(guardian.id);
 
@@ -33,23 +33,30 @@ export class GuardiansService {
           averageDuration: 0,
           overallMood: { positive: 0, negative: 0 },
         },
+        aiSummary: '',
         alerts: [],
         recentCalls: [],
       };
     }
 
     this.logger.log(
-      `getDashboard guardianId=${guardian.id} wardId=${linkedWard.id}`,
+      `getDashboard guardianId=${guardian.id} wardId=${linkedWard.id} period=${period ?? 'default'}`,
     );
+
+    // 기간에 따른 일수 계산
+    const days = period === 'today' ? 1 : period === 'month' ? 30 : 7;
 
     const [stats, weeklyChange, moodStats, alerts, recentCalls] =
       await Promise.all([
-        this.dbService.getWardCallStats(linkedWard.id),
+        this.dbService.getWardCallStats(linkedWard.id, days),
         this.dbService.getWardWeeklyCallChange(linkedWard.id),
-        this.dbService.getWardMoodStats(linkedWard.id),
+        this.dbService.getWardMoodStats(linkedWard.id, days),
         this.dbService.getHealthAlerts(guardian.id, 5),
         this.dbService.getRecentCallSummaries(linkedWard.id, 5),
       ]);
+
+    // aiSummary 생성 (최근 통화 기반)
+    const aiSummary = this.generateAiSummary(recentCalls, linkedWard.user_nickname);
 
     return {
       statistics: {
@@ -58,9 +65,32 @@ export class GuardiansService {
         averageDuration: stats.avgDuration,
         overallMood: moodStats,
       },
+      aiSummary,
       alerts,
       recentCalls,
     };
+  }
+
+  private generateAiSummary(
+    recentCalls: Array<{ summary?: string | null; mood?: string | null }>,
+    wardName?: string | null,
+  ): string {
+    if (recentCalls.length === 0) {
+      return wardName
+        ? `${wardName}님과의 최근 통화 기록이 없습니다.`
+        : '최근 통화 기록이 없습니다.';
+    }
+
+    const latestCall = recentCalls[0];
+    const displayName = wardName ?? '어르신';
+
+    if (latestCall.mood === 'positive') {
+      return `보호자님! ${displayName}님이 오늘 컨디션이 아주 좋으세요. ${latestCall.summary ?? ''}`;
+    } else if (latestCall.mood === 'negative') {
+      return `${displayName}님의 컨디션이 좋지 않아 보입니다. 관심이 필요해요. ${latestCall.summary ?? ''}`;
+    }
+
+    return `${displayName}님과 대화를 나눴어요. ${latestCall.summary ?? ''}`;
   }
 
   async getReport(userId: string, period: 'week' | 'month') {
@@ -145,7 +175,34 @@ export class GuardiansService {
     };
   }
 
-  async addWard(userId: string, wardEmail: string, wardPhoneNumber: string) {
+  async addWard(
+    userId: string,
+    wardEmail: string,
+    wardPhoneNumber: string,
+    options?: {
+      wardBasicInfo?: {
+        name?: string;
+        relation?: string;
+        phoneNumber?: string;
+        birthDate?: string;
+        gender?: string;
+        address?: string;
+      };
+      aiCareInfo?: {
+        medicalConditions?: string;
+        medications?: string;
+      };
+      callSchedule?: {
+        isEnabled: boolean;
+        items: Array<{
+          id?: string;
+          time: string;
+          weekdays: number[];
+          isEnabled: boolean;
+        }>;
+      };
+    },
+  ) {
     const { guardian } = await this.verifyGuardianAccess(userId);
     this.logger.log(`addWard guardianId=${guardian.id} wardEmail=${wardEmail}`);
 
@@ -153,7 +210,23 @@ export class GuardiansService {
       guardianId: guardian.id,
       wardEmail,
       wardPhoneNumber,
+      wardName: options?.wardBasicInfo?.name,
+      relation: options?.wardBasicInfo?.relation,
+      birthDate: options?.wardBasicInfo?.birthDate,
+      gender: options?.wardBasicInfo?.gender,
+      address: options?.wardBasicInfo?.address,
+      medicalConditions: options?.aiCareInfo?.medicalConditions,
+      medications: options?.aiCareInfo?.medications,
     });
+
+    // 스케줄 생성 (callSchedule이 있고 enabled인 경우)
+    if (options?.callSchedule?.isEnabled && options.callSchedule.items.length > 0) {
+      await this.dbService.createCallScheduleGroups(
+        registration.id,
+        null,
+        options.callSchedule.items,
+      );
+    }
 
     return {
       id: registration.id,
@@ -271,5 +344,66 @@ export class GuardiansService {
       callComplete: updated.call_complete,
       healthAlert: updated.health_alert,
     };
+  }
+
+  async getSchedules(userId: string) {
+    const { guardian } = await this.verifyGuardianAccess(userId);
+    this.logger.log(`getSchedules guardianId=${guardian.id}`);
+
+    const schedules = await this.dbService.getCallScheduleGroups(guardian.id);
+
+    return {
+      isEnabled: schedules.length > 0 && schedules.some(s => s.is_enabled),
+      items: schedules.map(s => ({
+        id: s.id,
+        time: s.time,
+        weekdays: s.weekdays,
+        isEnabled: s.is_enabled,
+      })),
+    };
+  }
+
+  async updateSchedules(
+    userId: string,
+    body: {
+      isEnabled: boolean;
+      items: Array<{
+        id?: string;
+        time: string;
+        weekdays: number[];
+        isEnabled: boolean;
+      }>;
+    },
+  ) {
+    const { guardian } = await this.verifyGuardianAccess(userId);
+    this.logger.log(`updateSchedules guardianId=${guardian.id}`);
+
+    const linkedWard = await this.dbService.findWardByGuardianId(guardian.id);
+
+    // 기존 스케줄 삭제 후 새로 생성 (upsert 방식)
+    await this.dbService.deleteCallScheduleGroupsByGuardian(guardian.id);
+
+    if (body.isEnabled && body.items.length > 0) {
+      // linkedWard가 있으면 wardId로, 없으면 registration으로
+      const registration = await this.dbService.findFirstGuardianWardRegistration(guardian.id);
+
+      await this.dbService.createCallScheduleGroups(
+        registration?.id ?? null,
+        linkedWard?.id ?? null,
+        body.items,
+      );
+    }
+
+    return this.getSchedules(userId);
+  }
+
+  async deleteSchedule(userId: string, scheduleId: string) {
+    const { guardian } = await this.verifyGuardianAccess(userId);
+    this.logger.log(`deleteSchedule guardianId=${guardian.id} scheduleId=${scheduleId}`);
+
+    const deleted = await this.dbService.deleteCallScheduleGroup(scheduleId, guardian.id);
+    if (!deleted) {
+      throw new HttpException('Schedule not found', HttpStatus.NOT_FOUND);
+    }
   }
 }

--- a/src/scheduler/notification.scheduler.ts
+++ b/src/scheduler/notification.scheduler.ts
@@ -7,6 +7,10 @@ import { CallsService } from '../calls/calls.service';
 export class NotificationScheduler {
   private readonly logger = new Logger(NotificationScheduler.name);
 
+  // 중복 발신 방지: 최근 발신된 스케줄 ID (5분간 유지)
+  private readonly recentlyCalledSchedules = new Map<string, number>();
+  private readonly DUPLICATE_PREVENTION_MS = 5 * 60 * 1000; // 5분
+
   constructor(
     private readonly dbService: DbService,
     private readonly callsService: CallsService,
@@ -129,6 +133,81 @@ export class NotificationScheduler {
       this.logger.error(
         `notifyCallComplete failed callId=${callId} error=${(error as Error).message}`,
       );
+    }
+  }
+
+  /**
+   * 스케줄된 시간에 자동 전화 발신
+   * 매 분 0초에 실행
+   */
+  @Cron('0 * * * * *')
+  async initiateScheduledCalls() {
+    const now = new Date();
+    const dayOfWeek = now.getDay(); // 0=일, 1=월, ..., 6=토
+    const currentTime = `${String(now.getHours()).padStart(2, '0')}:${String(now.getMinutes()).padStart(2, '0')}`;
+
+    // 오래된 캐시 정리
+    this.cleanupRecentlyCalled();
+
+    try {
+      const schedules = await this.dbService.getSchedulesForCurrentTime(
+        dayOfWeek,
+        currentTime,
+      );
+
+      if (schedules.length === 0) {
+        return; // 조용히 종료
+      }
+
+      this.logger.log(
+        `initiateScheduledCalls dayOfWeek=${dayOfWeek} time=${currentTime} found=${schedules.length}`,
+      );
+
+      for (const schedule of schedules) {
+        // 중복 발신 방지
+        if (this.recentlyCalledSchedules.has(schedule.schedule_id)) {
+          this.logger.log(
+            `initiateScheduledCalls skip duplicate scheduleId=${schedule.schedule_id}`,
+          );
+          continue;
+        }
+
+        try {
+          // 전화 발신
+          const result = await this.callsService.inviteCall({
+            callerIdentity: 'ai-scheduler',
+            callerName: schedule.ai_persona,
+            calleeIdentity: schedule.ward_identity,
+          });
+
+          // 중복 방지 캐시에 추가
+          this.recentlyCalledSchedules.set(schedule.schedule_id, Date.now());
+
+          this.logger.log(
+            `initiateScheduledCalls success scheduleId=${schedule.schedule_id} wardIdentity=${schedule.ward_identity} callId=${result.callId} roomName=${result.roomName}`,
+          );
+        } catch (callError) {
+          this.logger.error(
+            `initiateScheduledCalls call failed scheduleId=${schedule.schedule_id} error=${(callError as Error).message}`,
+          );
+        }
+      }
+    } catch (error) {
+      this.logger.error(
+        `initiateScheduledCalls failed error=${(error as Error).message}`,
+      );
+    }
+  }
+
+  /**
+   * 오래된 중복 방지 캐시 정리
+   */
+  private cleanupRecentlyCalled() {
+    const now = Date.now();
+    for (const [scheduleId, timestamp] of this.recentlyCalledSchedules) {
+      if (now - timestamp > this.DUPLICATE_PREVENTION_MS) {
+        this.recentlyCalledSchedules.delete(scheduleId);
+      }
     }
   }
 }

--- a/src/users/dto/register-guardian.dto.ts
+++ b/src/users/dto/register-guardian.dto.ts
@@ -1,6 +1,35 @@
+export class WardBasicInfoDto {
+  name?: string;
+  relation?: string; // 'parent' | 'grandparent' | 'spouse' | 'relative' | 'other'
+  phoneNumber?: string;
+  birthDate?: string; // YYYYMMDD
+  gender?: string; // 'male' | 'female'
+  address?: string;
+}
+
+export class AiCareInfoDto {
+  medicalConditions?: string;
+  medications?: string;
+}
+
+export class CallScheduleItemDto {
+  id?: string;
+  time: string; // "HH:mm"
+  weekdays: number[]; // [0-6], 0=일요일
+  isEnabled: boolean;
+}
+
+export class CallScheduleDto {
+  isEnabled: boolean;
+  items: CallScheduleItemDto[];
+}
+
 export class RegisterGuardianDto {
   wardEmail?: string;
   wardPhoneNumber?: string;
+  wardBasicInfo?: WardBasicInfoDto;
+  aiCareInfo?: AiCareInfoDto;
+  callSchedule?: CallScheduleDto;
 }
 
 export class RegisterGuardianResponseDto {
@@ -15,6 +44,7 @@ export class RegisterGuardianResponseDto {
   };
   guardianInfo: {
     id: string;
+    registrationId: string;
     wardEmail: string;
     wardPhoneNumber: string;
     linkedWard: null;

--- a/src/users/dto/user-response.dto.ts
+++ b/src/users/dto/user-response.dto.ts
@@ -7,8 +7,9 @@ export class UserResponseDto {
   createdAt: string;
   guardianInfo?: {
     id: string;
-    wardEmail: string;
-    wardPhoneNumber: string;
+    registrationId: string | null;
+    wardEmail: string | null;
+    wardPhoneNumber: string | null;
     linkedWard: {
       id: string;
       nickname: string | null;
@@ -22,6 +23,10 @@ export class UserResponseDto {
       id: string;
       nickname: string | null;
       profileImageUrl: string | null;
+    } | null;
+    linkedOrganization: {
+      id: string;
+      name: string;
     } | null;
   } | null;
 }

--- a/src/users/users.controller.ts
+++ b/src/users/users.controller.ts
@@ -99,6 +99,9 @@ export class UsersController {
         accessToken,
         wardEmail,
         wardPhoneNumber,
+        wardBasicInfo: body.wardBasicInfo,
+        aiCareInfo: body.aiCareInfo,
+        callSchedule: body.callSchedule,
       });
       return result;
     } catch (error) {

--- a/src/users/users.service.ts
+++ b/src/users/users.service.ts
@@ -22,6 +22,10 @@ export class UsersService {
 
     if (user.user_type === 'guardian') {
       const guardian = await this.dbService.findGuardianByUserId(user.id);
+      // 첫 번째 어르신 등록 정보 가져오기
+      const firstRegistration = guardian
+        ? await this.dbService.findFirstGuardianWardRegistration(guardian.id)
+        : undefined;
       const linkedWard = guardian
         ? await this.dbService.findWardByGuardianId(guardian.id)
         : undefined;
@@ -31,8 +35,9 @@ export class UsersService {
         guardianInfo: guardian
           ? {
               id: guardian.id,
-              wardEmail: guardian.ward_email,
-              wardPhoneNumber: guardian.ward_phone_number,
+              registrationId: firstRegistration?.id ?? null,
+              wardEmail: firstRegistration?.ward_email ?? null,
+              wardPhoneNumber: firstRegistration?.ward_phone_number ?? null,
               linkedWard: linkedWard
                 ? {
                     id: linkedWard.user_id,


### PR DESCRIPTION
## 개요

Care Alerts 시스템 구현 및 보호자-피보호자 관리 기능 확장

Closes #92

## 주요 변경사항

### 1. Care Alerts 모듈 (`src/care-alerts/`)
- **알림 타입**: emotion(감정), device_fall(기기 낙상), person_fall(사람 낙상), loud_voice(큰 소리)
- **감정 데이터 처리**: 10분 주기 버퍼링 및 집계 → EmotionSummary 저장
- **즉시 알림**: 낙상/큰 소리 감지 시 APNs + WebSocket 전송
- **REST API**:
  - `POST /v1/care-alerts` - Ward 알림 수신
  - `GET /v1/guardians/wards/:wardId/alerts` - 보호자용 알림 조회
  - `GET /v1/guardians/wards/:wardId/emotion-report` - 감정 리포트
  - `PATCH /v1/guardians/alerts/:alertId/acknowledge` - 알림 확인

### 2. 보호자-피보호자 관계 관리
- Guardian-Ward 매칭 기능 확장
- 보호자별 피보호자 목록 조회 API

### 3. 개발용 보호자 인증
- 테스트/개발 환경용 보호자 인증 DTO 추가

### 4. DB 스키마 확장
- `care_alert_events` 테이블
- `emotion_summaries` 테이블
- 관련 인덱스 및 FK

## 영향 범위

| 구분 | 파일 |
|------|------|
| 신규 | `src/care-alerts/*`, `src/auth/dto/dev-guardian.dto.ts` |
| 수정 | DB 스키마, guardians, users, auth, scheduler 모듈 |

## 테스트

- [x] Prisma 스키마 유효성 검증
- [x] 빌드 성공 확인
- [ ] API 엔드포인트 테스트

## 체크리스트

- [x] 코드 컨벤션 준수
- [x] 커밋 메시지 규칙 준수
- [x] DB 스키마 init-db.sql 동기화