### PR TITLE
fix(guardian): 보호자-어르신 연결 및 스케줄 저장 버그 수정

### DIFF
--- a/src/auth/auth.service.ts
+++ b/src/auth/auth.service.ts
@@ -642,15 +642,14 @@ export class AuthService {
       };
     }
 
-    // 2. 새 guardian 생성 - wardPhoneNumber 필수
-    if (!params.wardPhoneNumber) {
-      throw new Error('wardPhoneNumber is required for new guardian');
-    }
-
+    // 2. 새 guardian 생성
     const dummyKakaoId = `dev_${Date.now()}_${Math.random().toString(36).substring(7)}`;
     const nickname =
       params.nickname || `테스트보호자_${Date.now().toString().slice(-4)}`;
     const email = params.email || `dev_${Date.now()}@test.local`;
+    // wardPhoneNumber가 없으면 더미 번호 생성
+    const wardPhoneNumber =
+      params.wardPhoneNumber || `010-0000-${Date.now().toString().slice(-4)}`;
 
     const user = await this.dbService.createUserWithKakao({
       kakaoId: dummyKakaoId,
@@ -667,7 +666,7 @@ export class AuthService {
       await this.dbService.registerGuardianWithTransaction({
         userId: user.id,
         wardEmail: params.wardEmail,
-        wardPhoneNumber: params.wardPhoneNumber,
+        wardPhoneNumber,
         wardBasicInfo: params.wardBasicInfo,
         aiCareInfo: params.aiCareInfo,
         callSchedule: params.callSchedule,

--- a/src/database/repositories/guardian.repository.ts
+++ b/src/database/repositories/guardian.repository.ts
@@ -532,33 +532,37 @@ export class GuardianRepository {
         const sortedWeekdays = [...item.weekdays].sort((a, b) => a - b);
 
         for (const weekday of sortedWeekdays) {
-          // SELECT FOR UPDATE로 해당 슬롯 행들 잠금
+          // 서브쿼리로 행 잠금 후 카운트 (PostgreSQL에서 aggregate + FOR UPDATE 불가)
           let result: [{ cnt: bigint }];
 
           if (wardId) {
             // 자기 자신(wardId) 제외하고 카운트
             result = await tx.$queryRaw<[{ cnt: bigint }]>`
-              SELECT COUNT(*) as cnt
-              FROM call_schedule_groups
-              WHERE slot_start_hour = ${item.slotStartHour}
-                AND slot_start_minute = ${item.slotStartMinute}
-                AND ${weekday} = ANY(weekdays)
-                AND is_enabled = TRUE
-                AND ward_id IS NOT NULL
-                AND ward_id != ${wardId}::uuid
-              FOR UPDATE
+              SELECT COUNT(*) as cnt FROM (
+                SELECT id
+                FROM call_schedule_groups
+                WHERE slot_start_hour = ${item.slotStartHour}
+                  AND slot_start_minute = ${item.slotStartMinute}
+                  AND ${weekday} = ANY(weekdays)
+                  AND is_enabled = TRUE
+                  AND ward_id IS NOT NULL
+                  AND ward_id != ${wardId}::uuid
+                FOR UPDATE
+              ) locked_rows
             `;
           } else {
             // wardId 없으면 전체 카운트
             result = await tx.$queryRaw<[{ cnt: bigint }]>`
-              SELECT COUNT(*) as cnt
-              FROM call_schedule_groups
-              WHERE slot_start_hour = ${item.slotStartHour}
-                AND slot_start_minute = ${item.slotStartMinute}
-                AND ${weekday} = ANY(weekdays)
-                AND is_enabled = TRUE
-                AND ward_id IS NOT NULL
-              FOR UPDATE
+              SELECT COUNT(*) as cnt FROM (
+                SELECT id
+                FROM call_schedule_groups
+                WHERE slot_start_hour = ${item.slotStartHour}
+                  AND slot_start_minute = ${item.slotStartMinute}
+                  AND ${weekday} = ANY(weekdays)
+                  AND is_enabled = TRUE
+                  AND ward_id IS NOT NULL
+                FOR UPDATE
+              ) locked_rows
             `;
           }
 

--- a/src/database/repositories/ward.repository.ts
+++ b/src/database/repositories/ward.repository.ts
@@ -147,8 +147,38 @@ export class WardRepository {
       })
     | undefined
   > {
-    const ward = await this.prisma.ward.findFirst({
-      where: { guardianId },
+    // guardian_ward_registrations를 통해 연결된 ward 조회
+    const registration = await this.prisma.guardianWardRegistration.findFirst({
+      where: {
+        guardianId,
+        linkedWardId: { not: null },
+      },
+      select: { linkedWardId: true },
+    });
+
+    if (!registration?.linkedWardId) {
+      // fallback: 기존 방식 (wards.guardian_id로 직접 연결)
+      const ward = await this.prisma.ward.findFirst({
+        where: { guardianId },
+        include: {
+          user: {
+            select: {
+              nickname: true,
+              profileImageUrl: true,
+            },
+          },
+        },
+      });
+      if (!ward) return undefined;
+      return {
+        ...toWardRow(ward),
+        user_nickname: ward.user.nickname,
+        user_profile_image_url: ward.user.profileImageUrl,
+      };
+    }
+
+    const ward = await this.prisma.ward.findUnique({
+      where: { id: registration.linkedWardId },
       include: {
         user: {
           select: {

--- a/src/users/users.service.ts
+++ b/src/users/users.service.ts
@@ -40,7 +40,7 @@ export class UsersService {
               wardPhoneNumber: firstRegistration?.ward_phone_number ?? null,
               linkedWard: linkedWard
                 ? {
-                    id: linkedWard.user_id,
+                    id: linkedWard.id,
                     nickname: linkedWard.user_nickname,
                     profileImageUrl: linkedWard.user_profile_image_url,
                   }


### PR DESCRIPTION
## Summary
- linkedWard.id가 ward.id 반환하도록 수정 (iOS 무한루프 해결)
- guardian_ward_registrations 통해 ward 조회 (연결 누락 해결)
- PostgreSQL FOR UPDATE + aggregate 에러 서브쿼리로 해결
- 개발용 보호자 wardPhoneNumber 옵션 처리

## Test plan
- [ ] 보호자 앱에서 /users/me 호출 시 linkedWard.id가 올바른 ward id 반환 확인
- [ ] 스케줄 저장 시 500 에러 없이 정상 저장 확인
- [ ] 개발용 보호자 생성 시 wardPhoneNumber 없이도 생성 가능 확인

Closes #101