### PR TITLE
fix: 보호자-어르신 연결 버그 수정 및 스케줄러 분산 락 구현

### DIFF
--- a/src/auth/auth.service.ts
+++ b/src/auth/auth.service.ts
@@ -642,15 +642,14 @@ export class AuthService {
       };
     }
 
-    // 2. 새 guardian 생성 - wardPhoneNumber 필수
-    if (!params.wardPhoneNumber) {
-      throw new Error('wardPhoneNumber is required for new guardian');
-    }
-
+    // 2. 새 guardian 생성
     const dummyKakaoId = `dev_${Date.now()}_${Math.random().toString(36).substring(7)}`;
     const nickname =
       params.nickname || `테스트보호자_${Date.now().toString().slice(-4)}`;
     const email = params.email || `dev_${Date.now()}@test.local`;
+    // wardPhoneNumber가 없으면 더미 번호 생성
+    const wardPhoneNumber =
+      params.wardPhoneNumber || `010-0000-${Date.now().toString().slice(-4)}`;
 
     const user = await this.dbService.createUserWithKakao({
       kakaoId: dummyKakaoId,
@@ -667,7 +666,7 @@ export class AuthService {
       await this.dbService.registerGuardianWithTransaction({
         userId: user.id,
         wardEmail: params.wardEmail,
-        wardPhoneNumber: params.wardPhoneNumber,
+        wardPhoneNumber,
         wardBasicInfo: params.wardBasicInfo,
         aiCareInfo: params.aiCareInfo,
         callSchedule: params.callSchedule,

--- a/src/database/repositories/guardian.repository.ts
+++ b/src/database/repositories/guardian.repository.ts
@@ -532,33 +532,37 @@ export class GuardianRepository {
         const sortedWeekdays = [...item.weekdays].sort((a, b) => a - b);
 
         for (const weekday of sortedWeekdays) {
-          // SELECT FOR UPDATE로 해당 슬롯 행들 잠금
+          // 서브쿼리로 행 잠금 후 카운트 (PostgreSQL에서 aggregate + FOR UPDATE 불가)
           let result: [{ cnt: bigint }];
 
           if (wardId) {
             // 자기 자신(wardId) 제외하고 카운트
             result = await tx.$queryRaw<[{ cnt: bigint }]>`
-              SELECT COUNT(*) as cnt
-              FROM call_schedule_groups
-              WHERE slot_start_hour = ${item.slotStartHour}
-                AND slot_start_minute = ${item.slotStartMinute}
-                AND ${weekday} = ANY(weekdays)
-                AND is_enabled = TRUE
-                AND ward_id IS NOT NULL
-                AND ward_id != ${wardId}::uuid
-              FOR UPDATE
+              SELECT COUNT(*) as cnt FROM (
+                SELECT id
+                FROM call_schedule_groups
+                WHERE slot_start_hour = ${item.slotStartHour}
+                  AND slot_start_minute = ${item.slotStartMinute}
+                  AND ${weekday} = ANY(weekdays)
+                  AND is_enabled = TRUE
+                  AND ward_id IS NOT NULL
+                  AND ward_id != ${wardId}::uuid
+                FOR UPDATE
+              ) locked_rows
             `;
           } else {
             // wardId 없으면 전체 카운트
             result = await tx.$queryRaw<[{ cnt: bigint }]>`
-              SELECT COUNT(*) as cnt
-              FROM call_schedule_groups
-              WHERE slot_start_hour = ${item.slotStartHour}
-                AND slot_start_minute = ${item.slotStartMinute}
-                AND ${weekday} = ANY(weekdays)
-                AND is_enabled = TRUE
-                AND ward_id IS NOT NULL
-              FOR UPDATE
+              SELECT COUNT(*) as cnt FROM (
+                SELECT id
+                FROM call_schedule_groups
+                WHERE slot_start_hour = ${item.slotStartHour}
+                  AND slot_start_minute = ${item.slotStartMinute}
+                  AND ${weekday} = ANY(weekdays)
+                  AND is_enabled = TRUE
+                  AND ward_id IS NOT NULL
+                FOR UPDATE
+              ) locked_rows
             `;
           }
 

--- a/src/database/repositories/ward.repository.ts
+++ b/src/database/repositories/ward.repository.ts
@@ -147,8 +147,38 @@ export class WardRepository {
       })
     | undefined
   > {
-    const ward = await this.prisma.ward.findFirst({
-      where: { guardianId },
+    // guardian_ward_registrations를 통해 연결된 ward 조회
+    const registration = await this.prisma.guardianWardRegistration.findFirst({
+      where: {
+        guardianId,
+        linkedWardId: { not: null },
+      },
+      select: { linkedWardId: true },
+    });
+
+    if (!registration?.linkedWardId) {
+      // fallback: 기존 방식 (wards.guardian_id로 직접 연결)
+      const ward = await this.prisma.ward.findFirst({
+        where: { guardianId },
+        include: {
+          user: {
+            select: {
+              nickname: true,
+              profileImageUrl: true,
+            },
+          },
+        },
+      });
+      if (!ward) return undefined;
+      return {
+        ...toWardRow(ward),
+        user_nickname: ward.user.nickname,
+        user_profile_image_url: ward.user.profileImageUrl,
+      };
+    }
+
+    const ward = await this.prisma.ward.findUnique({
+      where: { id: registration.linkedWardId },
       include: {
         user: {
           select: {

--- a/src/scheduler/notification.scheduler.spec.ts
+++ b/src/scheduler/notification.scheduler.spec.ts
@@ -1,0 +1,172 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { NotificationScheduler } from './notification.scheduler';
+import { DbService } from '../database';
+import { CallsService } from '../calls/calls.service';
+
+// Mock Redis client
+const mockRedisClient = {
+    connect: jest.fn(),
+    quit: jest.fn(),
+    set: jest.fn(),
+};
+
+jest.mock('redis', () => ({
+    createClient: jest.fn(() => mockRedisClient),
+}));
+
+describe('NotificationScheduler', () => {
+    let scheduler: NotificationScheduler;
+    let mockDbService: Partial<DbService>;
+    let mockCallsService: Partial<CallsService>;
+
+    beforeEach(async () => {
+        // Reset mocks
+        jest.clearAllMocks();
+        mockRedisClient.set.mockReset();
+
+        mockDbService = {
+            getUpcomingCallSchedules: jest.fn().mockResolvedValue([]),
+            getMissedCalls: jest.fn().mockResolvedValue([]),
+            getSchedulesForCurrentSlot: jest.fn().mockResolvedValue([]),
+            markReminderSent: jest.fn().mockResolvedValue(undefined),
+        };
+
+        mockCallsService = {
+            sendUserPush: jest.fn().mockResolvedValue(undefined),
+            inviteCall: jest.fn().mockResolvedValue({ callId: 'test-call-id', roomName: 'test-room' }),
+        };
+
+        // Set REDIS_URL for tests
+        process.env.REDIS_URL = 'redis://localhost:6379';
+
+        const module: TestingModule = await Test.createTestingModule({
+            providers: [
+                NotificationScheduler,
+                { provide: DbService, useValue: mockDbService },
+                { provide: CallsService, useValue: mockCallsService },
+            ],
+        }).compile();
+
+        scheduler = module.get<NotificationScheduler>(NotificationScheduler);
+        await scheduler.onModuleInit();
+    });
+
+    afterEach(async () => {
+        await scheduler.onModuleDestroy();
+    });
+
+    describe('Distributed Lock - tryAcquireLock', () => {
+        it('should acquire lock when Redis SET NX succeeds', async () => {
+            mockRedisClient.set.mockResolvedValue('OK');
+
+            // Access private method via type assertion
+            const result = await (scheduler as any).tryAcquireLock('test:lock:key');
+
+            expect(result).toBe(true);
+            expect(mockRedisClient.set).toHaveBeenCalledWith(
+                'test:lock:key',
+                expect.any(String), // process.pid
+                { NX: true, EX: 300 }
+            );
+        });
+
+        it('should fail to acquire lock when key already exists', async () => {
+            mockRedisClient.set.mockResolvedValue(null);
+
+            const result = await (scheduler as any).tryAcquireLock('test:lock:key');
+
+            expect(result).toBe(false);
+        });
+
+        it('should return true when Redis throws error (fallback behavior)', async () => {
+            mockRedisClient.set.mockRejectedValue(new Error('Redis connection error'));
+
+            const result = await (scheduler as any).tryAcquireLock('test:lock:key');
+
+            expect(result).toBe(true); // 에러 시 진행 허용
+        });
+    });
+
+    describe('checkCallReminders - Lock Integration', () => {
+        it('should skip execution when lock already exists', async () => {
+            mockRedisClient.set.mockResolvedValue(null); // Lock exists
+
+            await scheduler.checkCallReminders();
+
+            expect(mockDbService.getUpcomingCallSchedules).not.toHaveBeenCalled();
+        });
+
+        it('should execute when lock acquired', async () => {
+            mockRedisClient.set.mockResolvedValue('OK');
+
+            await scheduler.checkCallReminders();
+
+            expect(mockDbService.getUpcomingCallSchedules).toHaveBeenCalled();
+        });
+    });
+
+    describe('checkMissedCalls - Lock Integration', () => {
+        it('should skip execution when lock already exists', async () => {
+            mockRedisClient.set.mockResolvedValue(null);
+
+            await scheduler.checkMissedCalls();
+
+            expect(mockDbService.getMissedCalls).not.toHaveBeenCalled();
+        });
+
+        it('should execute when lock acquired', async () => {
+            mockRedisClient.set.mockResolvedValue('OK');
+
+            await scheduler.checkMissedCalls();
+
+            expect(mockDbService.getMissedCalls).toHaveBeenCalled();
+        });
+    });
+
+    describe('initiateScheduledCalls - Lock Integration', () => {
+        it('should skip execution when lock already exists', async () => {
+            mockRedisClient.set.mockResolvedValue(null);
+
+            await scheduler.initiateScheduledCalls();
+
+            expect(mockDbService.getSchedulesForCurrentSlot).not.toHaveBeenCalled();
+        });
+
+        it('should execute when lock acquired', async () => {
+            mockRedisClient.set.mockResolvedValue('OK');
+
+            await scheduler.initiateScheduledCalls();
+
+            expect(mockDbService.getSchedulesForCurrentSlot).toHaveBeenCalled();
+        });
+    });
+
+    describe('Lock Key Generation', () => {
+        it('should generate correct lock key for reminders', async () => {
+            mockRedisClient.set.mockResolvedValue('OK');
+
+            await scheduler.checkCallReminders();
+
+            const lockKeyArg = mockRedisClient.set.mock.calls[0][0];
+            expect(lockKeyArg).toMatch(/^scheduler:reminder:\d+:(00|30)$/);
+        });
+
+        it('should generate correct lock key for missed calls', async () => {
+            mockRedisClient.set.mockResolvedValue('OK');
+
+            await scheduler.checkMissedCalls();
+
+            const lockKeyArg = mockRedisClient.set.mock.calls[0][0];
+            expect(lockKeyArg).toMatch(/^scheduler:missed:\d+$/);
+        });
+
+        it('should generate correct lock key for scheduled calls', async () => {
+            mockRedisClient.set.mockResolvedValue('OK');
+
+            await scheduler.initiateScheduledCalls();
+
+            const lockKeyArg = mockRedisClient.set.mock.calls[0][0];
+            expect(lockKeyArg).toMatch(/^scheduler:call:\d+:\d{2}$/);
+        });
+    });
+});

--- a/src/scheduler/notification.scheduler.ts
+++ b/src/scheduler/notification.scheduler.ts
@@ -1,20 +1,68 @@
-import { Injectable, Logger } from '@nestjs/common';
+import { Injectable, Logger, OnModuleInit, OnModuleDestroy } from '@nestjs/common';
 import { Cron, CronExpression } from '@nestjs/schedule';
 import { DbService } from '../database';
 import { CallsService } from '../calls/calls.service';
+import { createClient, type RedisClientType } from 'redis';
 
 @Injectable()
-export class NotificationScheduler {
+export class NotificationScheduler implements OnModuleInit, OnModuleDestroy {
   private readonly logger = new Logger(NotificationScheduler.name);
 
   // 중복 발신 방지: 최근 발신된 스케줄 ID (5분간 유지)
   private readonly recentlyCalledSchedules = new Map<string, number>();
   private readonly DUPLICATE_PREVENTION_MS = 5 * 60 * 1000; // 5분
 
+  // Redis 분산 락
+  private redisClient: RedisClientType | null = null;
+  private readonly LOCK_TTL_SECONDS = 300; // 5분
+
   constructor(
     private readonly dbService: DbService,
     private readonly callsService: CallsService,
-  ) {}
+  ) { }
+
+  async onModuleInit() {
+    const redisUrl = process.env.REDIS_URL;
+    if (redisUrl) {
+      try {
+        this.redisClient = createClient({ url: redisUrl });
+        await this.redisClient.connect();
+        this.logger.log('Redis connected for scheduler distributed lock');
+      } catch (error) {
+        this.logger.warn(`Redis connection failed for scheduler lock: ${(error as Error).message}`);
+        this.redisClient = null;
+      }
+    } else {
+      this.logger.warn('REDIS_URL not set - scheduler lock disabled');
+    }
+  }
+
+  async onModuleDestroy() {
+    if (this.redisClient) {
+      await this.redisClient.quit();
+    }
+  }
+
+  /**
+   * 분산 락 획득 시도
+   * @returns true if lock acquired, false if already locked
+   */
+  private async tryAcquireLock(lockKey: string): Promise<boolean> {
+    if (!this.redisClient) {
+      return true; // Redis 없으면 락 없이 진행 (단일 인스턴스 가정)
+    }
+
+    try {
+      const result = await this.redisClient.set(lockKey, process.pid.toString(), {
+        NX: true, // Only set if not exists
+        EX: this.LOCK_TTL_SECONDS,
+      });
+      return result === 'OK';
+    } catch (error) {
+      this.logger.error(`Lock acquire failed: ${(error as Error).message}`);
+      return true; // 에러 시 진행 (락 없이)
+    }
+  }
 
   // 매 30분마다 리마인더 체크 (예: 09:00, 09:30, 10:00, ...)
   @Cron(CronExpression.EVERY_30_MINUTES)
@@ -23,6 +71,14 @@ export class NotificationScheduler {
     const dayOfWeek = now.getDay(); // 0=일, 1=월, ..., 6=토
     const currentHour = now.getHours();
     const currentMinute = now.getMinutes();
+
+    // 분산 락 획득 시도
+    const lockKey = `scheduler:reminder:${currentHour}:${currentMinute < 30 ? '00' : '30'}`;
+    const acquired = await this.tryAcquireLock(lockKey);
+    if (!acquired) {
+      this.logger.debug(`checkCallReminders skipped - lock exists: ${lockKey}`);
+      return;
+    }
 
     // 30분 후 예정된 통화 확인
     const targetTime = new Date(now.getTime() + 30 * 60 * 1000);
@@ -67,6 +123,14 @@ export class NotificationScheduler {
   // 매 시간 미진행 통화 체크
   @Cron(CronExpression.EVERY_HOUR)
   async checkMissedCalls() {
+    const now = new Date();
+    const lockKey = `scheduler:missed:${now.getHours()}`;
+    const acquired = await this.tryAcquireLock(lockKey);
+    if (!acquired) {
+      this.logger.debug(`checkMissedCalls skipped - lock exists: ${lockKey}`);
+      return;
+    }
+
     this.logger.log('checkMissedCalls started');
 
     try {
@@ -146,6 +210,14 @@ export class NotificationScheduler {
     const dayOfWeek = now.getDay(); // 0=일, 1=월, ..., 6=토
     const slotStartHour = now.getHours();
     const slotStartMinute = Math.floor(now.getMinutes() / 10) * 10; // 10분 단위로 정규화
+
+    // 분산 락 획득 시도
+    const lockKey = `scheduler:call:${slotStartHour}:${String(slotStartMinute).padStart(2, '0')}`;
+    const acquired = await this.tryAcquireLock(lockKey);
+    if (!acquired) {
+      this.logger.debug(`initiateScheduledCalls skipped - lock exists: ${lockKey}`);
+      return;
+    }
 
     // 오래된 캐시 정리
     this.cleanupRecentlyCalled();

--- a/src/users/users.service.ts
+++ b/src/users/users.service.ts
@@ -40,7 +40,7 @@ export class UsersService {
               wardPhoneNumber: firstRegistration?.ward_phone_number ?? null,
               linkedWard: linkedWard
                 ? {
-                    id: linkedWard.user_id,
+                    id: linkedWard.id,
                     nickname: linkedWard.user_nickname,
                     profileImageUrl: linkedWard.user_profile_image_url,
                   }


### PR DESCRIPTION
## 개요
보호자-어르신 연결 관련 버그를 수정하고, 다중 인스턴스 환경에서 스케줄러 중복 실행을 방지하기 위한 Redis 분산 락을 구현했습니다.

---

## 변경사항

### 1. 보호자-어르신 연결 버그 수정 (#101)

| 파일 | 변경 내용 |
|------|----------|
| auth.service.ts | 개발용 보호자 wardPhoneNumber 옵션 처리 (더미 번호 자동 생성) |
| guardian.repository.ts | linkedWard.id가 ward.id 반환하도록 수정, findByGuardianId가 guardian_ward_registrations 통해 조회 |
| ward.repository.ts | PostgreSQL FOR UPDATE + aggregate 에러 서브쿼리로 해결 |
| users.service.ts | 연관 수정 |

### 2. 스케줄러 분산 락 구현 (#103)

| 파일 | 변경 내용 |
|------|----------|
| notification.scheduler.ts | Redis 클라이언트 연결, tryAcquireLock() 구현 (SET NX EX 패턴), 3개 크론 잡에 적용 |
| notification.scheduler.spec.ts | 12개 유닛 테스트 추가 |

---

## 테스트
- ✅ 분산 락 유닛 테스트 12개 통과
- ✅ 보호자-어르신 연결 수동 테스트 완료

---

## 통계
- **6개 파일** 변경
- **307 줄 추가**, **30 줄 삭제**

---

## 관련 이슈
- Closes #101
- Closes #103