### PR TITLE
chore: update superagent to 10.3.0 (security fix)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11461,9 +11461,9 @@
       }
     },
     "node_modules/superagent": {
-      "version": "10.2.3",
-      "resolved": "https://registry.npmjs.org/superagent/-/superagent-10.2.3.tgz",
-      "integrity": "sha512-y/hkYGeXAj7wUMjxRbB21g/l6aAEituGXM9Rwl4o20+SX3e8YOSV6BxFXl+dL3Uk0mjSL3kCbNkwURm8/gEDig==",
+      "version": "10.3.0",
+      "resolved": "https://registry.npmjs.org/superagent/-/superagent-10.3.0.tgz",
+      "integrity": "sha512-B+4Ik7ROgVKrQsXTV0Jwp2u+PXYLSlqtDAhYnkkD+zn3yg8s/zjA2MeGayPoY/KICrbitwneDHrjSotxKL+0XQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -11471,11 +11471,11 @@
         "cookiejar": "^2.1.4",
         "debug": "^4.3.7",
         "fast-safe-stringify": "^2.1.1",
-        "form-data": "^4.0.4",
+        "form-data": "^4.0.5",
         "formidable": "^3.5.4",
         "methods": "^1.1.2",
         "mime": "2.6.0",
-        "qs": "^6.11.2"
+        "qs": "^6.14.1"
       },
       "engines": {
         "node": ">=14.18.0"


### PR DESCRIPTION
 Updates `superagent` to v10.3.0 to resolve a high-severity vulnerability in its dependency `qs`.

- **Vulnerability**: CVE-2025-24965 (DoS via memory exhaustion in `qs`)
- **Fix**: Upgraded `superagent` which bumps `qs` requirement from `^6.11.2` to `^6.14.1`.
- **Note**: The legacy lockfile was pinning `superagent` to 10.2.3 despite 10.3.0 being installed. This syncs the lockfile.

Closes Dependabot alert #1.