### PR TITLE
chore: force qs version ^6.14.1 via overrides (security fix)

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,6 +41,9 @@
     "reflect-metadata": "^0.2.2",
     "rxjs": "^7.8.1"
   },
+  "overrides": {
+    "qs": "^6.14.1"
+  },
   "devDependencies": {
     "@eslint/eslintrc": "^3.2.0",
     "@eslint/js": "^9.18.0",


### PR DESCRIPTION
This PR adds `overrides` to `package.json` to enforce `qs` version `^6.14.1`.

Previously merged PR #106 only synchronized the lockfile, which might not be sufficient if nested dependencies request older versions. This override ensures `qs` is pinned to the secure version across the entire dependency tree, resolving Dependabot alert #1.

Closes Dependabot alert #1.