### PR TITLE
fix: hasActiveCall이 answered 상태만 활성 통화로 인식하도록 수정

### DIFF
--- a/src/database/db.service.ts
+++ b/src/database/db.service.ts
@@ -275,8 +275,8 @@ export class DbService implements OnModuleDestroy {
     return this.calls.getActiveCallCount();
   }
 
-  async hasActiveCall(userId: string) {
-    return this.calls.hasActiveCall(userId);
+  async hasActiveCall(userId: string, excludeRingingRoom?: string) {
+    return this.calls.hasActiveCall(userId, excludeRingingRoom);
   }
 
   // ============================================================

--- a/src/database/repositories/call.repository.ts
+++ b/src/database/repositories/call.repository.ts
@@ -10,7 +10,7 @@ import { toCallRow, toCallSummaryRow } from '../prisma-mappers';
 
 @Injectable()
 export class CallRepository {
-  constructor(private readonly prisma: PrismaService) {}
+  constructor(private readonly prisma: PrismaService) { }
 
   async findRinging(
     calleeIdentity: string,
@@ -85,8 +85,8 @@ export class CallRepository {
       const duration =
         s.call.answeredAt && s.call.endedAt
           ? Math.round(
-              (s.call.endedAt.getTime() - s.call.answeredAt.getTime()) / 60000,
-            )
+            (s.call.endedAt.getTime() - s.call.answeredAt.getTime()) / 60000,
+          )
           : 0;
       return {
         id: s.id,
@@ -150,13 +150,13 @@ export class CallRepository {
     const recentCalls =
       wardUserIds.length > 0
         ? await this.prisma.call.groupBy({
-            by: ['calleeUserId'],
-            where: {
-              calleeUserId: { in: wardUserIds },
-              state: 'ended',
-              createdAt: { gt: cutoff },
-            },
-          })
+          by: ['calleeUserId'],
+          where: {
+            calleeUserId: { in: wardUserIds },
+            state: 'ended',
+            createdAt: { gt: cutoff },
+          },
+        })
         : [];
     const hasRecentCallSet = new Set(recentCalls.map(c => c.calleeUserId));
 
@@ -342,13 +342,25 @@ export class CallRepository {
 
   /**
    * 특정 사용자가 이미 활성 통화 중인지 확인
+   * @param userId 사용자 ID
+   * @param excludeRingingRoom 예약 통화 수락 시, 해당 room의 ringing call은 제외
    */
-  async hasActiveCall(userId: string): Promise<boolean> {
+  async hasActiveCall(
+    userId: string,
+    excludeRingingRoom?: string,
+  ): Promise<boolean> {
+    // ringing 상태는 "전화벨 울리는 중"이지 "통화 중"이 아니므로
+    // answered 상태만 "활성 통화"로 간주
     const count = await this.prisma.call.count({
       where: {
         OR: [{ callerUserId: userId }, { calleeUserId: userId }],
-        state: { not: 'ended' },
+        state: 'answered',  // ringing이 아닌 answered만 체크
         endedAt: null,
+        // 예약 통화 수락 시, 해당 room의 ringing call은 "중복 통화"로 간주하지 않음
+        // (이 로직은 ringing 체크가 아니므로 사실상 불필요하지만, 명시성을 위해 유지)
+        NOT: excludeRingingRoom
+          ? { roomName: excludeRingingRoom, state: 'ringing' }
+          : undefined,
       },
     });
     return count > 0;

--- a/src/rtc/rtc-token.service.ts
+++ b/src/rtc/rtc-token.service.ts
@@ -117,8 +117,12 @@ export class RtcTokenService {
     const expiresAt = new Date(Date.now() + ttlSeconds * 1000).toISOString();
 
     // Generate unique room name for iOS users
+    // BUT if iOS provides a valid roomName (from scheduled call push), use it
     const isIosUser = !!(params.device?.apnsToken || params.device?.voipToken);
-    const roomName = isIosUser ? `room-${randomUUID()}` : params.roomName;
+    const isScheduledCall = params.roomName && params.roomName.startsWith('room-');
+    const roomName = isScheduledCall
+      ? params.roomName
+      : (isIosUser ? `room-${randomUUID()}` : params.roomName);
 
     const deviceSummary = params.device
       ? `apns=${this.summarizeToken(params.device.apnsToken)} voip=${this.summarizeToken(params.device.voipToken)} env=${params.device.env ?? 'default'} platform=${params.device.platform ?? 'ios'}`
@@ -176,15 +180,19 @@ export class RtcTokenService {
     // Web admins don't create rooms, they only join existing rooms created by iOS users
     if (isIosUser) {
       // 용량 체크: 동시 통화 제한 및 중복 통화 방지
+      // 예약 통화 수락 시, 해당 room의 ringing call은 "중복 통화"로 간주하지 않음
       const [activeCallCount, hasActiveCall, slotConfig] = await Promise.all([
         this.dbService.getActiveCallCount(),
-        this.dbService.hasActiveCall(user.id),
+        this.dbService.hasActiveCall(
+          user.id,
+          isScheduledCall ? roomName : undefined,
+        ),
         this.dbService.getSlotConfig(),
       ]);
 
       if (hasActiveCall) {
         this.logger.warn(
-          `issueToken rejected - user already in call userId=${user.id}`,
+          `issueToken rejected - user already in call userId=${user.id} (isScheduledCall=${isScheduledCall})`,
         );
         throw new HttpException(
           {
@@ -289,23 +297,40 @@ export class RtcTokenService {
         );
       }
 
-      try {
-        const call = await this.dbService.createCall({
-          callerIdentity: AUTO_CALLER_IDENTITY,
-          calleeIdentity: identity,
-          calleeUserId: user.id,
-          roomName,
-        });
-        callId = call.id;
-        this.logger.log(
-          `Auto call record created callId=${callId} room=${roomName} identity=${identity}`,
-        );
-      } catch (error) {
-        this.logger.warn(
-          `Auto call record failed room=${roomName} identity=${identity} error=${(
-            error as Error
-          ).message}`,
-        );
+      // 예약 통화 수락 시 기존 ringing call 사용, 새 통화 시 call 레코드 생성
+      if (isScheduledCall) {
+        // 예약 통화: 기존 ringing call 찾기
+        const existingCall = await this.dbService.findRingingCall(identity, roomName, 120);
+        if (existingCall) {
+          callId = existingCall.callId;
+          this.logger.log(
+            `Scheduled call accepted - using existing callId=${callId} room=${roomName}`,
+          );
+        } else {
+          this.logger.warn(
+            `Scheduled call but no ringing record found room=${roomName} identity=${identity}`,
+          );
+        }
+      } else {
+        // 새 통화: call 레코드 생성
+        try {
+          const call = await this.dbService.createCall({
+            callerIdentity: AUTO_CALLER_IDENTITY,
+            calleeIdentity: identity,
+            calleeUserId: user.id,
+            roomName,
+          });
+          callId = call.id;
+          this.logger.log(
+            `Auto call record created callId=${callId} room=${roomName} identity=${identity}`,
+          );
+        } catch (error) {
+          this.logger.warn(
+            `Auto call record failed room=${roomName} identity=${identity} error=${(
+              error as Error
+            ).message}`,
+          );
+        }
       }
     } else {
       // Web admin - don't create room, just log


### PR DESCRIPTION
## 변경 사항
- `hasActiveCall()`에서 `ringing` 상태를 제외하고 `answered`만 체크
- 예약 통화 수락 시 기존 `ringing` call 레코드 재사용
- `excludeRingingRoom` 파라미터 추가로 유연성 확보

## 문제
- `ringing` 상태가 활성 통화로 잘못 인식되어 새 통화 시도가 차단됨
- 예약 통화 수락 시 '이미 진행 중인 통화가 있습니다' 오류 발생

## 테스트
- [x] iOS에서 예약 통화 수락 가능 확인
- [x] 기존 `ringing` 레코드가 새 통화를 차단하지 않음 확인

Closes #114