### PR TITLE
[Feature]하이브리드 검색(Vector + FTS) 도입 및 RRF 기반 랭킹 아키텍처 개편

### DIFF
--- a/init-db.sql
+++ b/init-db.sql
@@ -423,6 +423,13 @@ CREATE TABLE "conversation_vectors_child" (
     "offset_end" INTEGER NOT NULL,
     "metadata" JSONB,                              -- { chunkIndex, header, contentLength, keywords, etc. }
     "created_at" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    -- Full-Text Search: Generated Column for hybrid search (Vector + FTS)
+    -- chunk_header gets weight 'A' (highest priority for dates/relations)
+    -- child_text gets weight 'C' (normal content)
+    "fts_tokens" tsvector GENERATED ALWAYS AS (
+        setweight(to_tsvector('simple', COALESCE("chunk_header", '')), 'A') ||
+        setweight(to_tsvector('simple', COALESCE("child_text", '')), 'C')
+    ) STORED,
 
     CONSTRAINT "conversation_vectors_child_pkey" PRIMARY KEY ("id")
 );
@@ -613,6 +620,8 @@ CREATE INDEX "conversation_vectors_child_created_at_idx" ON "conversation_vector
 CREATE INDEX "conversation_vectors_child_ward_id_created_at_idx" ON "conversation_vectors_child"("ward_id", "created_at" DESC);
 -- HNSW index for fast vector similarity search (m=16, ef_construction=64)
 CREATE INDEX "conversation_vectors_child_embedding_idx" ON "conversation_vectors_child" USING hnsw (embedding vector_cosine_ops) WITH (m = 16, ef_construction = 64);
+-- GIN index for Full-Text Search (hybrid search support)
+CREATE INDEX "conversation_vectors_child_fts_tokens_idx" ON "conversation_vectors_child" USING GIN ("fts_tokens");
 
 -- Care alert events indexes
 CREATE INDEX "care_alert_events_ward_id_timestamp_idx" ON "care_alert_events"("ward_id", "timestamp" DESC);

--- a/src/ai/ai.module.ts
+++ b/src/ai/ai.module.ts
@@ -15,6 +15,11 @@ import { RagCacheService } from './rag/rag.cache.service';
 import { RagMetricsService } from './rag/rag.metrics.service';
 import { RagSummaryService } from './rag/rag.summary.service';
 
+// Hybrid Search 서비스들
+import { RagSearchRepository } from './rag/rag.search.repository';
+import { RagRankFusionService } from './rag/rag.rank-fusion.service';
+import { RagHybridSearchService } from './rag/rag.hybrid-search.service';
+
 // AI Providers
 import { OpenAiProvider } from './providers/openai.provider';
 import { BedrockProvider } from './providers/bedrock.provider';
@@ -33,9 +38,14 @@ import { DEFAULT_AI_INSTRUCTION, AI_RESPONSE_SCHEMA } from './ai.constants';
  * - RagRepository: DB CRUD (Parent-Child 트랜잭션)
  * - RagSummaryService: LLM 기반 고밀도 요약 생성
  * - RagEmbeddingService: Bedrock Titan 임베딩 생성
- * - RagSearchService: PGVector 검색
+ * - RagSearchService: 하이브리드 검색 (Vector + FTS + RRF)
  * - RagCacheService: Redis 캐시 관리
  * - RagMetricsService: 성능 메트릭 추적
+ *
+ * Hybrid Search 아키텍처:
+ * - RagSearchRepository: Vector 및 FTS 쿼리 실행
+ * - RagRankFusionService: RRF 알고리즘 구현
+ * - RagHybridSearchService: 병렬 검색 오케스트레이션
  *
  * @Global() 데코레이터로 전역 모듈로 등록
  */
@@ -58,6 +68,11 @@ import { DEFAULT_AI_INSTRUCTION, AI_RESPONSE_SCHEMA } from './ai.constants';
     RagCacheService,
     RagMetricsService,
     RagSummaryService,
+
+    // Hybrid Search 서비스 (Vector + FTS + RRF)
+    RagSearchRepository,
+    RagRankFusionService,
+    RagHybridSearchService,
 
     // AI Analysis Provider (Factory)
     {

--- a/src/ai/rag.service.ts
+++ b/src/ai/rag.service.ts
@@ -33,7 +33,7 @@ import {
  * - RagProcessor: 요약 생성 + 청킹 + 임베딩 로직
  * - RagRepository: DB CRUD (Parent-Child 트랜잭션)
  * - RagEmbeddingService: Bedrock Titan 임베딩 생성
- * - RagSearchService: PGVector 검색
+ * - RagSearchService: 하이브리드 검색 (Vector + FTS + RRF)
  * - RagCacheService: Redis 캐시 관리
  * - RagMetricsService: 성능 메트릭 추적
  *
@@ -171,17 +171,18 @@ export class RagService implements OnModuleInit {
 
     try {
       // Step 1-2: 요약 + 청크 생성 + 임베딩 (Single LLM Call)
-      const summaryResult =
-        await this.processor.processWithDenseSummary(transcripts, callDate);
+      const summaryResult = await this.processor.processWithDenseSummary(
+        transcripts,
+        callDate,
+      );
 
       this.logger.log(
         `✅ Dense summary generated: ${summaryResult.metadata.chunkCount} chunks`,
       );
 
       // Step 3: DB 저장 (트랜잭션)
-      const embeddedChunkBatches = this.processor.embedContextualChunksInBatches(
-        summaryResult.chunks,
-      );
+      const embeddedChunkBatches =
+        this.processor.embedContextualChunksInBatches(summaryResult.chunks);
       const parentId = await this.repository.saveWithDenseSummary(
         wardId,
         callId,
@@ -192,7 +193,7 @@ export class RagService implements OnModuleInit {
       );
 
       this.logger.log(
-        `✅ Dense Summary indexing complete: call=${callId}, parentId=${parentId}, ${embeddedChunks.length} chunks`,
+        `✅ Dense Summary indexing complete: call=${callId}, parentId=${parentId}, ${summaryResult.metadata.chunkCount} chunks`,
       );
     } catch (error) {
       this.logger.error(
@@ -275,7 +276,10 @@ export class RagService implements OnModuleInit {
    *
    * Hybrid 검색:
    * 1. Redis 캐시 확인 (Fast Path)
-   * 2. PGVector 검색 (Slow Path - Fallback)
+   * 2. Hybrid Search (Slow Path - Fallback)
+   *    - Vector Search (pgvector)
+   *    - Full-Text Search (PostgreSQL FTS)
+   *    - RRF (Reciprocal Rank Fusion)
    */
   async searchSimilar(
     wardId: string,
@@ -321,11 +325,13 @@ export class RagService implements OnModuleInit {
       this.logger.warn(`⚠️ Redis cache MISS - falling back to PGVector`);
 
       // 🔍 PGVector 검색 (Slow Path)
+      // 하이브리드 검색: Vector + FTS + RRF
       const pgStartTime = Date.now();
       const pgResults = await this.searchService.searchPGVector(
         wardId,
         queryEmbedding,
         searchLimit,
+        query, // FTS를 위한 쿼리 전달
       );
       const pgSearchTime = Date.now() - pgStartTime;
       this.metricsService.recordPgvectorSearch(pgSearchTime);
@@ -336,10 +342,7 @@ export class RagService implements OnModuleInit {
 
       return pgResults;
     } catch (error) {
-      this.logger.error(
-        `❌ RAG search failed: ${error.message}`,
-        error.stack,
-      );
+      this.logger.error(`❌ RAG search failed: ${error.message}`, error.stack);
       throw error;
     }
   }
@@ -435,9 +438,7 @@ export class RagService implements OnModuleInit {
 
       this.logger.log(`Fallback greeting cached/published for ward=${wardId}`);
     } catch (error) {
-      this.logger.warn(
-        `Failed to cache fallback greeting: ${error.message}`,
-      );
+      this.logger.warn(`Failed to cache fallback greeting: ${error.message}`);
     }
   }
 

--- a/src/ai/rag.service.ts
+++ b/src/ai/rag.service.ts
@@ -14,6 +14,7 @@ import { RagEmbeddingService } from './rag/rag.embedding.service';
 import { RagSearchService } from './rag/rag.search.service';
 import { RagCacheService } from './rag/rag.cache.service';
 import { RagMetricsService } from './rag/rag.metrics.service';
+import { isValidEmbedding } from './rag/rag.utils';
 
 // Types
 import {
@@ -297,32 +298,51 @@ export class RagService implements OnModuleInit {
       );
 
       // Query 임베딩 생성
-      const embeddingStartTime = Date.now();
-      const queryEmbedding =
-        await this.embeddingService.generateEmbedding(query);
-      const embeddingTime = Date.now() - embeddingStartTime;
-      this.debug(`📝 Embedding generated in ${embeddingTime}ms`);
-
-      // 🚀 Redis 캐시 검색 (Fast Path)
-      const redisStartTime = Date.now();
-      const cached = await this.cacheService.searchRedisCache(
-        wardId,
-        queryEmbedding,
-        searchLimit,
-      );
-      const redisSearchTime = Date.now() - redisStartTime;
-
-      if (cached && cached.length > 0) {
-        this.metricsService.recordCacheHit(redisSearchTime);
-        this.logger.log(
-          `✅ Redis cache HIT: ${cached.length} results (${redisSearchTime}ms)`,
+      let queryEmbedding: number[] = [];
+      try {
+        const embeddingStartTime = Date.now();
+        queryEmbedding = await this.embeddingService.generateEmbedding(query);
+        const embeddingTime = Date.now() - embeddingStartTime;
+        this.debug(`📝 Embedding generated in ${embeddingTime}ms`);
+      } catch (error) {
+        const message = error instanceof Error ? error.message : String(error);
+        this.logger.warn(
+          `⚠️ Embedding generation failed, falling back to FTS-only search: ${message}`,
         );
-        return cached;
       }
 
-      // Cache miss
+      const hasValidEmbedding = isValidEmbedding(queryEmbedding);
+
+      // 🚀 Redis 캐시 검색 (Fast Path)
+      if (hasValidEmbedding) {
+        const redisStartTime = Date.now();
+        const cached = await this.cacheService.searchRedisCache(
+          wardId,
+          queryEmbedding,
+          searchLimit,
+        );
+        const redisSearchTime = Date.now() - redisStartTime;
+
+        if (cached && cached.length > 0) {
+          this.metricsService.recordCacheHit(redisSearchTime);
+          this.logger.log(
+            `✅ Redis cache HIT: ${cached.length} results (${redisSearchTime}ms)`,
+          );
+          return cached;
+        }
+      } else {
+        this.logger.warn(
+          '⚠️ Invalid embedding detected - skipping Redis cache search',
+        );
+      }
+
+      // Cache miss or skip
       this.metricsService.recordCacheMiss();
-      this.logger.warn(`⚠️ Redis cache MISS - falling back to PGVector`);
+      this.logger.warn(
+        hasValidEmbedding
+          ? '⚠️ Redis cache MISS - falling back to Hybrid Search'
+          : '⚠️ Redis cache skipped - proceeding to Hybrid Search (invalid embedding)',
+      );
 
       // 🔍 PGVector 검색 (Slow Path)
       // 하이브리드 검색: Vector + FTS + RRF
@@ -337,7 +357,7 @@ export class RagService implements OnModuleInit {
       this.metricsService.recordPgvectorSearch(pgSearchTime);
 
       this.logger.log(
-        `✅ PGVector search: ${pgResults.length} results (${pgSearchTime}ms)`,
+        `✅ Hybrid search: ${pgResults.length} results (${pgSearchTime}ms)`,
       );
 
       return pgResults;

--- a/src/ai/rag/rag.cache.service.ts
+++ b/src/ai/rag/rag.cache.service.ts
@@ -374,7 +374,7 @@ export class RagCacheService implements OnModuleInit {
    */
   private async getCachedVectors(
     wardId: string,
-  ): Promise<{ key: string; vectors: any[] } | null> {
+  ): Promise<{ key: string; vectors: unknown[] } | null> {
     if (!this.redisClient) {
       return null;
     }
@@ -385,7 +385,14 @@ export class RagCacheService implements OnModuleInit {
 
     if (primary) {
       try {
-        return { key: primaryKey, vectors: JSON.parse(primary) };
+        const parsed = JSON.parse(primary);
+        if (!Array.isArray(parsed)) {
+          this.logger.warn(
+            `Invalid cached vectors payload for key=${primaryKey}`,
+          );
+          return null;
+        }
+        return { key: primaryKey, vectors: parsed };
       } catch (error) {
         this.logger.warn(
           `Failed to parse cached vectors for key=${primaryKey}: ${error.message}`,

--- a/src/ai/rag/rag.cache.service.ts
+++ b/src/ai/rag/rag.cache.service.ts
@@ -27,7 +27,6 @@ export class RagCacheService implements OnModuleInit {
     10,
   );
   private readonly VECTOR_CACHE_VERSION = 'v2';
-  private readonly LEGACY_VECTOR_CACHE_VERSION = 'v1';
   private readonly GREETING_CACHE_VERSION = 'v1';
 
   constructor(private readonly prisma: PrismaService) {}
@@ -357,13 +356,6 @@ export class RagCacheService implements OnModuleInit {
   }
 
   /**
-   * Get legacy Redis vectors cache key (pre parent-child)
-   */
-  getLegacyRedisVectorsKey(wardId: string): string {
-    return `rag:${this.LEGACY_VECTOR_CACHE_VERSION}:ward:${wardId}:vectors`;
-  }
-
-  /**
    * Get greeting cache key
    */
   getGreetingCacheKey(wardId: string): string {
@@ -377,9 +369,12 @@ export class RagCacheService implements OnModuleInit {
     return this.redisClient;
   }
 
+  /**
+   * Get cached vectors from Redis (internal use)
+   */
   private async getCachedVectors(
     wardId: string,
-  ): Promise<{ key: string; vectors: unknown[] } | null> {
+  ): Promise<{ key: string; vectors: any[] } | null> {
     if (!this.redisClient) {
       return null;
     }
@@ -387,6 +382,7 @@ export class RagCacheService implements OnModuleInit {
     const primaryKey = this.getRedisVectorsKey(wardId);
     this.logger.debug(`Checking cache key: ${primaryKey}`);
     const primary = await this.redisClient.get(primaryKey);
+
     if (primary) {
       try {
         return { key: primaryKey, vectors: JSON.parse(primary) };
@@ -398,22 +394,7 @@ export class RagCacheService implements OnModuleInit {
       }
     }
 
-    const legacyKey = this.getLegacyRedisVectorsKey(wardId);
-    const legacy = await this.redisClient.get(legacyKey);
-    if (!legacy) {
-      this.logger.debug(`Cache key not found: ${primaryKey}`);
-      return null;
-    }
-
-    this.logger.warn(`Legacy cache key hit: ${legacyKey}`);
-
-    try {
-      return { key: legacyKey, vectors: JSON.parse(legacy) };
-    } catch (error) {
-      this.logger.warn(
-        `Failed to parse cached vectors for key=${legacyKey}: ${error.message}`,
-      );
-      return null;
-    }
+    this.logger.debug(`Cache key not found: ${primaryKey}`);
+    return null;
   }
 }

--- a/src/ai/rag/rag.hybrid-search.service.ts
+++ b/src/ai/rag/rag.hybrid-search.service.ts
@@ -1,0 +1,112 @@
+import { Injectable, Logger } from '@nestjs/common';
+import { RagSearchRepository } from './rag.search.repository';
+import { RagRankFusionService } from './rag.rank-fusion.service';
+import { SearchResult } from './rag.types';
+
+/**
+ * Hybrid Search Service
+ *
+ * 벡터 검색과 Full-Text Search를 병렬로 실행하고 RRF로 결합하는 오케스트레이션 레이어:
+ * - Promise.all로 두 검색을 병렬 실행
+ * - 키워드 추출 및 전처리
+ * - RRF 알고리즘으로 최종 결과 생성
+ */
+@Injectable()
+export class RagHybridSearchService {
+  private readonly logger = new Logger(RagHybridSearchService.name);
+
+  private readonly DEBUG_LOGS = process.env.RAG_DEBUG_LOGS === 'true';
+
+  // 검색 결과 확장 배수 (RRF 적용 전 더 많은 후보 수집)
+  private readonly SEARCH_EXPANSION_FACTOR = 2;
+
+  constructor(
+    private readonly searchRepository: RagSearchRepository,
+    private readonly rankFusionService: RagRankFusionService,
+  ) {}
+
+  /**
+   * 하이브리드 검색 실행
+   *
+   * @param wardId 어르신 ID
+   * @param query 사용자 쿼리 (키워드 추출용)
+   * @param queryEmbedding 쿼리 임베딩 벡터
+   * @param limit 최종 반환할 결과 수
+   * @returns RRF로 결합된 검색 결과
+   */
+  async search(
+    wardId: string,
+    query: string,
+    queryEmbedding: number[],
+    limit: number,
+  ): Promise<SearchResult[]> {
+    try {
+      this.debug(
+        `Hybrid search: ward=${wardId.substring(0, 8)}..., query="${query}", limit=${limit}`,
+      );
+
+      // Step 1: 키워드 추출
+      const keywords = this.extractKeywords(query);
+      this.debug(`Extracted keywords: "${keywords}"`);
+
+      // Step 2: 병렬 검색 실행 (더 많은 후보 수집)
+      const expandedLimit = limit * this.SEARCH_EXPANSION_FACTOR;
+
+      const [vectorResults, ftsResults] = await Promise.all([
+        this.searchRepository.searchVector(
+          wardId,
+          queryEmbedding,
+          expandedLimit,
+        ),
+        keywords
+          ? this.searchRepository.searchFullText(
+              wardId,
+              keywords,
+              expandedLimit,
+            )
+          : Promise.resolve([]),
+      ]);
+
+      this.logger.log(
+        `Search completed: vector=${vectorResults.length}, fts=${ftsResults.length}`,
+      );
+
+      // Step 3: RRF 적용하여 결과 결합
+      const fusedResults = this.rankFusionService.fuseResults(
+        vectorResults,
+        ftsResults,
+        limit,
+      );
+
+      this.logger.log(`Hybrid search returned ${fusedResults.length} results`);
+
+      return fusedResults;
+    } catch (error) {
+      this.logger.error(`Hybrid search failed: ${error.message}`, error.stack);
+      throw error;
+    }
+  }
+
+  /**
+   * 사용자 쿼리에서 검색 키워드 추출
+   *
+   * @param query 사용자 쿼리
+   * @returns 검색 키워드 (trim 처리)
+   */
+  private extractKeywords(query: string): string {
+    if (!query || query.trim().length === 0) {
+      return '';
+    }
+
+    const normalized = query.trim();
+    this.debug(`Extracted keywords from "${query}" -> "${normalized}"`);
+
+    return normalized;
+  }
+
+  private debug(message: string): void {
+    if (this.DEBUG_LOGS) {
+      this.logger.debug(message);
+    }
+  }
+}

--- a/src/ai/rag/rag.hybrid-search.service.ts
+++ b/src/ai/rag/rag.hybrid-search.service.ts
@@ -2,6 +2,7 @@ import { Injectable, Logger } from '@nestjs/common';
 import { RagSearchRepository } from './rag.search.repository';
 import { RagRankFusionService } from './rag.rank-fusion.service';
 import { SearchResult } from './rag.types';
+import { isValidEmbedding } from './rag.utils';
 
 /**
  * Hybrid Search Service
@@ -19,6 +20,25 @@ export class RagHybridSearchService {
 
   // 검색 결과 확장 배수 (RRF 적용 전 더 많은 후보 수집)
   private readonly SEARCH_EXPANSION_FACTOR = 2;
+
+  private readonly VECTOR_SEARCH_TIMEOUT_MS = (() => {
+    const value = parseInt(
+      process.env.RAG_VECTOR_SEARCH_TIMEOUT_MS ||
+        process.env.RAG_SEARCH_TIMEOUT_MS ||
+        '2000',
+      10,
+    );
+    return Number.isFinite(value) && value > 0 ? value : 2000;
+  })();
+  private readonly FTS_SEARCH_TIMEOUT_MS = (() => {
+    const value = parseInt(
+      process.env.RAG_FTS_SEARCH_TIMEOUT_MS ||
+        process.env.RAG_SEARCH_TIMEOUT_MS ||
+        '2000',
+      10,
+    );
+    return Number.isFinite(value) && value > 0 ? value : 2000;
+  })();
 
   constructor(
     private readonly searchRepository: RagSearchRepository,
@@ -52,19 +72,42 @@ export class RagHybridSearchService {
       // Step 2: 병렬 검색 실행 (더 많은 후보 수집)
       const expandedLimit = limit * this.SEARCH_EXPANSION_FACTOR;
 
+      const hasValidEmbedding = isValidEmbedding(queryEmbedding);
+      const vectorSearch = hasValidEmbedding
+        ? this.runSearchWithTimeout(
+            'vector',
+            () =>
+              this.searchRepository.searchVector(
+                wardId,
+                queryEmbedding,
+                expandedLimit,
+              ),
+            this.VECTOR_SEARCH_TIMEOUT_MS,
+            [],
+          )
+        : Promise.resolve([]);
+
+      if (!hasValidEmbedding) {
+        this.logger.warn('Invalid embedding detected - skipping vector search');
+      }
+
+      const ftsSearch = keywords
+        ? this.runSearchWithTimeout(
+            'fts',
+            () =>
+              this.searchRepository.searchFullText(
+                wardId,
+                keywords,
+                expandedLimit,
+              ),
+            this.FTS_SEARCH_TIMEOUT_MS,
+            [],
+          )
+        : Promise.resolve([]);
+
       const [vectorResults, ftsResults] = await Promise.all([
-        this.searchRepository.searchVector(
-          wardId,
-          queryEmbedding,
-          expandedLimit,
-        ),
-        keywords
-          ? this.searchRepository.searchFullText(
-              wardId,
-              keywords,
-              expandedLimit,
-            )
-          : Promise.resolve([]),
+        vectorSearch,
+        ftsSearch,
       ]);
 
       this.logger.log(
@@ -107,6 +150,54 @@ export class RagHybridSearchService {
   private debug(message: string): void {
     if (this.DEBUG_LOGS) {
       this.logger.debug(message);
+    }
+  }
+
+  private async runSearchWithTimeout<T>(
+    label: string,
+    task: () => Promise<T>,
+    timeoutMs: number,
+    fallback: T,
+  ): Promise<T> {
+    const safeTimeoutMs =
+      Number.isFinite(timeoutMs) && timeoutMs > 0 ? timeoutMs : 0;
+
+    if (!safeTimeoutMs) {
+      return this.runSearchSafely(label, task, fallback);
+    }
+
+    const taskPromise = this.runSearchSafely(label, task, fallback);
+    let timeoutId: ReturnType<typeof setTimeout> | null = null;
+
+    const timeoutPromise = new Promise<T>(resolve => {
+      timeoutId = setTimeout(() => {
+        this.logger.warn(
+          `Hybrid search ${label} timed out after ${safeTimeoutMs}ms`,
+        );
+        resolve(fallback);
+      }, safeTimeoutMs);
+    });
+
+    const result = await Promise.race([taskPromise, timeoutPromise]);
+
+    if (timeoutId) {
+      clearTimeout(timeoutId);
+    }
+
+    return result;
+  }
+
+  private async runSearchSafely<T>(
+    label: string,
+    task: () => Promise<T>,
+    fallback: T,
+  ): Promise<T> {
+    try {
+      return await task();
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      this.logger.warn(`Hybrid search ${label} failed: ${message}`);
+      return fallback;
     }
   }
 }

--- a/src/ai/rag/rag.rank-fusion.service.ts
+++ b/src/ai/rag/rag.rank-fusion.service.ts
@@ -1,0 +1,170 @@
+import { Injectable, Logger } from '@nestjs/common';
+import { SearchResult } from './rag.types';
+
+/**
+ * Rank Fusion Service
+ *
+ * RRF(Reciprocal Rank Fusion) 알고리즘을 사용한 검색 결과 순위 합산:
+ * - 벡터 검색과 FTS 결과를 결합
+ * - RRF 공식: score = Σ 1/(k + rank)
+ * - Zero-Result 처리: 벡터 검색 결과가 없을 때 FTS 추천 제공
+ */
+@Injectable()
+export class RagRankFusionService {
+  private readonly logger = new Logger(RagRankFusionService.name);
+
+  // RRF 파라미터 k: 순위 차이를 완화하는 상수
+  // k가 클수록 순위 차이가 덜 중요해짐
+  private readonly RRF_K = parseInt(process.env.RRF_K || '60', 10);
+
+  private readonly DEBUG_LOGS = process.env.RAG_DEBUG_LOGS === 'true';
+
+  /**
+   * RRF 알고리즘으로 벡터 검색과 FTS 결과 결합
+   *
+   * @param vectorResults 벡터 검색 결과
+   * @param ftsResults Full-Text Search 결과
+   * @param limit 최종 반환할 결과 수
+   * @returns RRF 점수로 정렬된 결과
+   */
+  fuseResults(
+    vectorResults: SearchResult[],
+    ftsResults: SearchResult[],
+    limit: number,
+  ): SearchResult[] {
+    this.debug(
+      `Fusing results: vector=${vectorResults.length}, fts=${ftsResults.length}`,
+    );
+
+    // Zero-Result 처리
+    if (vectorResults.length === 0 && ftsResults.length === 0) {
+      this.logger.warn('No results from both vector and FTS search');
+      return [];
+    }
+
+    if (vectorResults.length === 0) {
+      this.logger.log(
+        `Zero vector results - returning top ${limit} FTS recommendations`,
+      );
+      return ftsResults.slice(0, limit);
+    }
+
+    if (ftsResults.length === 0) {
+      this.debug('Zero FTS results - returning vector results only');
+      return vectorResults.slice(0, limit);
+    }
+
+    // Step 1: 각 결과에 순위 부여 (1-based)
+    const vectorRanks = new Map<string, number>(
+      vectorResults.map((r, i) => [this.getResultId(r), i + 1]),
+    );
+    const ftsRanks = new Map<string, number>(
+      ftsResults.map((r, i) => [this.getResultId(r), i + 1]),
+    );
+
+    // Step 2: 모든 고유 결과 ID 수집
+    const allIds = new Set([...vectorRanks.keys(), ...ftsRanks.keys()]);
+
+    this.debug(`Total unique results: ${allIds.size}`);
+
+    // Step 3: RRF 점수 계산
+    const scoredResults: Array<{
+      id: string;
+      result: SearchResult;
+      rrfScore: number;
+      vectorRank?: number;
+      ftsRank?: number;
+    }> = [];
+
+    // 결과를 ID로 빠르게 조회하기 위한 Map
+    const resultMap = new Map<string, SearchResult>();
+    vectorResults.forEach(r => resultMap.set(this.getResultId(r), r));
+    ftsResults.forEach(r => resultMap.set(this.getResultId(r), r));
+
+    for (const id of allIds) {
+      const vectorRank = vectorRanks.get(id);
+      const ftsRank = ftsRanks.get(id);
+
+      // RRF 공식: score = 1/(k + vectorRank) + 1/(k + ftsRank)
+      const rrfScore =
+        (vectorRank ? 1 / (this.RRF_K + vectorRank) : 0) +
+        (ftsRank ? 1 / (this.RRF_K + ftsRank) : 0);
+
+      const result = resultMap.get(id);
+      if (result) {
+        scoredResults.push({
+          id,
+          result,
+          rrfScore,
+          vectorRank,
+          ftsRank,
+        });
+      }
+    }
+
+    // Step 4: RRF 점수로 정렬
+    scoredResults.sort((a, b) => b.rrfScore - a.rrfScore);
+
+    // Step 5: 상위 N개 선택
+    const topResults = scoredResults.slice(0, limit);
+
+    if (this.DEBUG_LOGS && topResults.length > 0) {
+      this.logger.debug(
+        `Top result: rrfScore=${topResults[0].rrfScore.toFixed(4)}, ` +
+          `vectorRank=${topResults[0].vectorRank || 'N/A'}, ` +
+          `ftsRank=${topResults[0].ftsRank || 'N/A'}`,
+      );
+    }
+
+    // Step 6: SearchResult 반환 (RRF 점수를 similarity에 저장)
+    return topResults.map(scored => ({
+      ...scored.result,
+      similarity: scored.rrfScore, // RRF 점수를 similarity 필드에 저장
+      metadata: {
+        ...scored.result.metadata,
+        rrfScore: scored.rrfScore,
+        vectorRank: scored.vectorRank,
+        ftsRank: scored.ftsRank,
+      },
+    }));
+  }
+
+  /**
+   * Zero-Result 처리: 벡터 검색 결과가 없을 때 FTS 추천 제공
+   *
+   * @param ftsResults FTS 검색 결과
+   * @param limit 추천할 결과 수
+   * @returns 추천 결과
+   */
+  handleZeroResults(ftsResults: SearchResult[], limit: number): SearchResult[] {
+    if (ftsResults.length === 0) {
+      return [];
+    }
+
+    this.logger.log(
+      `Providing ${Math.min(ftsResults.length, limit)} FTS recommendations for zero-result query`,
+    );
+
+    return ftsResults.slice(0, limit).map(r => ({
+      ...r,
+      metadata: {
+        ...r.metadata,
+        isRecommendation: true, // 추천 결과임을 표시
+      },
+    }));
+  }
+
+  /**
+   * 결과의 고유 ID 생성 (parent_id 기준)
+   * Parent-Child 구조에서 중복 제거를 위해 parent_id 사용
+   */
+  private getResultId(result: SearchResult): string {
+    return result.parentId || result.callId || result.text.substring(0, 50);
+  }
+
+  private debug(message: string): void {
+    if (this.DEBUG_LOGS) {
+      this.logger.debug(message);
+    }
+  }
+}

--- a/src/ai/rag/rag.search.repository.ts
+++ b/src/ai/rag/rag.search.repository.ts
@@ -1,0 +1,285 @@
+import { Injectable, Logger } from '@nestjs/common';
+import { PrismaService } from '../../prisma/prisma.service';
+import { Prisma } from '@prisma/client';
+import { RagMetadata, SearchResult } from './rag.types';
+import { getWindowContext } from './rag.utils';
+
+/**
+ * RAG Search Repository
+ *
+ * DB 검색 쿼리를 담당하는 레포지토리 레이어:
+ * - Vector Search: pgvector 기반 유사도 검색
+ * - Full-Text Search: PostgreSQL ts_rank 기반 키워드 검색
+ * - SRP 원칙: 검색 쿼리만 담당
+ */
+@Injectable()
+export class RagSearchRepository {
+  private readonly logger = new Logger(RagSearchRepository.name);
+
+  private readonly SIMILARITY_THRESHOLD = parseFloat(
+    process.env.SIMILARITY_THRESHOLD || '0.4',
+  );
+
+  private readonly CHILD_SEARCH_MULTIPLIER = (() => {
+    const value = parseInt(process.env.RAG_CHILD_SEARCH_MULTIPLIER || '3', 10);
+    return Number.isFinite(value) && value > 0 ? value : 3;
+  })();
+
+  private readonly WINDOW_CONTEXT_CHARS = parseInt(
+    process.env.RAG_WINDOW_CONTEXT_CHARS || '150',
+    10,
+  );
+
+  private readonly DEBUG_LOGS = process.env.RAG_DEBUG_LOGS === 'true';
+
+  constructor(private readonly prisma: PrismaService) {}
+
+  /**
+   * Vector Search: pgvector 기반 유사도 검색
+   *
+   * Parent-Child 구조를 활용하여 검색:
+   * 1. Child 벡터에서 유사도 검색
+   * 2. Parent ID로 그룹화하여 중복 제거
+   * 3. Parent 텍스트와 함께 반환
+   */
+  async searchVector(
+    wardId: string,
+    queryEmbedding: number[],
+    limit: number,
+  ): Promise<SearchResult[]> {
+    try {
+      const embeddingStr = JSON.stringify(queryEmbedding);
+      const expandedLimit = Math.max(
+        limit,
+        limit * this.CHILD_SEARCH_MULTIPLIER,
+      );
+
+      this.debug(
+        `Vector search: ward=${wardId.substring(0, 8)}..., limit=${expandedLimit}`,
+      );
+
+      // Step 1: Child 벡터 검색 + Parent 조인
+      const childResults = await this.prisma.$queryRaw<
+        Array<{
+          child_id: string;
+          child_text: string;
+          chunk_header: string | null;
+          parent_id: string;
+          parent_text: string;
+          offset_start: number;
+          offset_end: number;
+          metadata: RagMetadata;
+          similarity: number;
+          created_at: Date;
+          call_id: string;
+        }>
+      >(
+        Prisma.sql`
+          SELECT
+            c.id AS child_id,
+            c.child_text,
+            c.chunk_header,
+            c.parent_id,
+            p.parent_text,
+            c.offset_start,
+            c.offset_end,
+            c.metadata,
+            1 - (c.embedding <=> ${embeddingStr}::vector) AS similarity,
+            c.created_at,
+            c.call_id
+          FROM conversation_vectors_child c
+          INNER JOIN conversation_vectors_parent p ON c.parent_id = p.id
+          WHERE c.ward_id = ${wardId}::uuid
+          ORDER BY c.embedding <=> ${embeddingStr}::vector
+          LIMIT ${expandedLimit}
+        `,
+      );
+
+      this.debug(
+        `Found ${childResults.length} child results from vector search`,
+      );
+
+      // Step 2: 유사도 임계값 필터링
+      const filtered = childResults.filter(
+        r => r.similarity >= this.SIMILARITY_THRESHOLD,
+      );
+
+      if (filtered.length < childResults.length) {
+        this.debug(
+          `Filtered ${childResults.length - filtered.length} results below threshold ${this.SIMILARITY_THRESHOLD}`,
+        );
+      }
+
+      // Step 3: Parent ID로 그룹화 (각 Parent당 가장 높은 유사도 Child만 선택)
+      const groupedByParent = new Map<string, (typeof filtered)[0]>();
+
+      for (const result of filtered) {
+        const existing = groupedByParent.get(result.parent_id);
+        if (!existing || result.similarity > existing.similarity) {
+          groupedByParent.set(result.parent_id, result);
+        }
+      }
+
+      // Step 4: 상위 N개 Parent 선택
+      const uniqueParents = Array.from(groupedByParent.values())
+        .sort((a, b) => b.similarity - a.similarity)
+        .slice(0, limit);
+
+      this.debug(
+        `Grouped ${filtered.length} children into ${uniqueParents.length} unique parents`,
+      );
+
+      // Step 5: SearchResult 생성 (Parent 컨텍스트 + 스니펫)
+      return uniqueParents.map(r => {
+        const snippet = getWindowContext(
+          r.parent_text,
+          r.offset_start,
+          r.offset_end,
+          this.WINDOW_CONTEXT_CHARS,
+        );
+
+        // chunk_header를 metadata에 포함
+        const metadata = {
+          ...r.metadata,
+          chunk_header: r.chunk_header || r.metadata?.chunk_header,
+        };
+
+        return {
+          text: snippet || r.parent_text,
+          childText: r.child_text,
+          parentText: r.parent_text,
+          parentId: r.parent_id,
+          snippet: snippet,
+          offsetStart: r.offset_start,
+          offsetEnd: r.offset_end,
+          metadata,
+          similarity: r.similarity,
+          createdAt: r.created_at.toISOString(),
+          callId: r.call_id,
+        };
+      });
+    } catch (error) {
+      this.logger.error(`Vector search failed: ${error.message}`, error.stack);
+      throw error;
+    }
+  }
+
+  /**
+   * Full-Text Search: ts_rank 기반 키워드 검색
+   *
+   * chunk_header(날짜, 관계 등)에 높은 가중치 부여:
+   * - chunk_header: weight 'A' (1.0)
+   * - child_text: weight 'C' (0.2)
+   *
+   * @param wardId 어르신 ID
+   * @param keywords 검색 키워드 (공백으로 구분)
+   * @param limit 반환할 최대 결과 수
+   */
+  async searchFullText(
+    wardId: string,
+    keywords: string,
+    limit: number,
+  ): Promise<SearchResult[]> {
+    try {
+      if (!keywords || keywords.trim().length === 0) {
+        this.debug('Empty keywords - skipping FTS');
+        return [];
+      }
+
+      this.debug(
+        `FTS search: ward=${wardId.substring(0, 8)}..., keywords="${keywords}", limit=${limit}`,
+      );
+
+      // 한글 복합어 지원을 위해 prefix 검색 사용
+      // "병원 예약" → "병원:* | 예약:*" (OR: 하나라도 매칭되면 검색)
+      const prefixKeywords = keywords
+        .split(/\s+/)
+        .filter(k => k.length > 0)
+        .map(k => `${k}:*`)
+        .join(' | ');
+
+      this.debug(`FTS prefix query: "${prefixKeywords}"`);
+
+      const results = await this.prisma.$queryRaw<
+        Array<{
+          child_id: string;
+          child_text: string;
+          chunk_header: string | null;
+          parent_id: string;
+          parent_text: string;
+          offset_start: number;
+          offset_end: number;
+          metadata: RagMetadata;
+          rank_score: number;
+          created_at: Date;
+          call_id: string;
+        }>
+      >(
+        Prisma.sql`
+          SELECT
+            c.id AS child_id,
+            c.child_text,
+            c.chunk_header,
+            c.parent_id,
+            p.parent_text,
+            c.offset_start,
+            c.offset_end,
+            c.metadata,
+            ts_rank(c.fts_tokens, query) AS rank_score,
+            c.created_at,
+            c.call_id
+          FROM conversation_vectors_child c
+          INNER JOIN conversation_vectors_parent p ON c.parent_id = p.id,
+          to_tsquery('simple', ${prefixKeywords}) query
+          WHERE c.ward_id = ${wardId}::uuid
+            AND c.fts_tokens @@ query
+          ORDER BY rank_score DESC
+          LIMIT ${limit}
+        `,
+      );
+
+      this.debug(`Found ${results.length} results from FTS`);
+
+      // SearchResult로 변환
+      return results.map(r => {
+        const snippet = getWindowContext(
+          r.parent_text,
+          r.offset_start,
+          r.offset_end,
+          this.WINDOW_CONTEXT_CHARS,
+        );
+
+        const metadata = {
+          ...r.metadata,
+          chunk_header: r.chunk_header || r.metadata?.chunk_header,
+        };
+
+        return {
+          text: snippet || r.parent_text,
+          childText: r.child_text,
+          parentText: r.parent_text,
+          parentId: r.parent_id,
+          snippet: snippet,
+          offsetStart: r.offset_start,
+          offsetEnd: r.offset_end,
+          metadata,
+          similarity: r.rank_score, // FTS에서는 rank_score를 similarity로 사용
+          createdAt: r.created_at.toISOString(),
+          callId: r.call_id,
+        };
+      });
+    } catch (error) {
+      this.logger.error(
+        `Full-text search failed: ${error.message}`,
+        error.stack,
+      );
+      throw error;
+    }
+  }
+
+  private debug(message: string): void {
+    if (this.DEBUG_LOGS) {
+      this.logger.debug(message);
+    }
+  }
+}

--- a/src/ai/rag/rag.search.repository.ts
+++ b/src/ai/rag/rag.search.repository.ts
@@ -2,7 +2,7 @@ import { Injectable, Logger } from '@nestjs/common';
 import { PrismaService } from '../../prisma/prisma.service';
 import { Prisma } from '@prisma/client';
 import { RagMetadata, SearchResult } from './rag.types';
-import { getWindowContext } from './rag.utils';
+import { getWindowContext, isValidEmbedding } from './rag.utils';
 
 /**
  * RAG Search Repository
@@ -32,6 +32,16 @@ export class RagSearchRepository {
 
   private readonly DEBUG_LOGS = process.env.RAG_DEBUG_LOGS === 'true';
 
+  private readonly MAX_FTS_TOKENS = (() => {
+    const value = parseInt(process.env.RAG_FTS_MAX_TOKENS || '8', 10);
+    return Number.isFinite(value) && value > 0 ? value : 8;
+  })();
+  private readonly MAX_FTS_TOKEN_LENGTH = (() => {
+    const value = parseInt(process.env.RAG_FTS_MAX_TOKEN_LENGTH || '32', 10);
+    return Number.isFinite(value) && value > 0 ? value : 32;
+  })();
+  private readonly FTS_UNSAFE_CHARS = /[^a-zA-Z0-9가-힣_]+/g;
+
   constructor(private readonly prisma: PrismaService) {}
 
   /**
@@ -48,6 +58,11 @@ export class RagSearchRepository {
     limit: number,
   ): Promise<SearchResult[]> {
     try {
+      if (!isValidEmbedding(queryEmbedding)) {
+        this.logger.warn('Invalid embedding - skipping vector search');
+        return [];
+      }
+
       const embeddingStr = JSON.stringify(queryEmbedding);
       const expandedLimit = Math.max(
         limit,
@@ -186,17 +201,20 @@ export class RagSearchRepository {
         return [];
       }
 
+      // Sanitize user input to avoid tsquery parsing issues
+      const tokens = this.sanitizeKeywords(keywords);
+      if (tokens.length === 0) {
+        this.debug('No valid keywords after sanitization - skipping FTS');
+        return [];
+      }
+
       this.debug(
         `FTS search: ward=${wardId.substring(0, 8)}..., keywords="${keywords}", limit=${limit}`,
       );
 
       // 한글 복합어 지원을 위해 prefix 검색 사용
       // "병원 예약" → "병원:* | 예약:*" (OR: 하나라도 매칭되면 검색)
-      const prefixKeywords = keywords
-        .split(/\s+/)
-        .filter(k => k.length > 0)
-        .map(k => `${k}:*`)
-        .join(' | ');
+      const prefixKeywords = tokens.map(k => `${k}:*`).join(' | ');
 
       this.debug(`FTS prefix query: "${prefixKeywords}"`);
 
@@ -225,14 +243,14 @@ export class RagSearchRepository {
             c.offset_start,
             c.offset_end,
             c.metadata,
-            ts_rank(c.fts_tokens, query) AS rank_score,
+            ts_rank(COALESCE(c.fts_tokens, ''::tsvector), query) AS rank_score,
             c.created_at,
             c.call_id
           FROM conversation_vectors_child c
           INNER JOIN conversation_vectors_parent p ON c.parent_id = p.id,
           to_tsquery('simple', ${prefixKeywords}) query
           WHERE c.ward_id = ${wardId}::uuid
-            AND c.fts_tokens @@ query
+            AND COALESCE(c.fts_tokens, ''::tsvector) @@ query
           ORDER BY rank_score DESC
           LIMIT ${limit}
         `,
@@ -281,5 +299,15 @@ export class RagSearchRepository {
     if (this.DEBUG_LOGS) {
       this.logger.debug(message);
     }
+  }
+
+  private sanitizeKeywords(keywords: string): string[] {
+    const tokens = keywords
+      .split(/\s+/)
+      .map(token => token.replace(this.FTS_UNSAFE_CHARS, '').trim())
+      .filter(token => token.length > 0)
+      .map(token => token.slice(0, this.MAX_FTS_TOKEN_LENGTH));
+
+    return tokens.slice(0, this.MAX_FTS_TOKENS);
   }
 }

--- a/src/ai/rag/rag.search.service.ts
+++ b/src/ai/rag/rag.search.service.ts
@@ -1,174 +1,52 @@
 import { Injectable, Logger } from '@nestjs/common';
-import { PrismaService } from '../../prisma/prisma.service';
-import { Prisma } from '@prisma/client';
-import { RagMetadata, SearchResult } from './rag.types';
-import { getWindowContext } from './rag.utils';
+import { RagHybridSearchService } from './rag.hybrid-search.service';
+import { SearchResult } from './rag.types';
 
 /**
  * RAG Search Service
  *
- * Handles PGVector search operations with Parent-Child structure:
- * - Searches child vectors for similarity matching
- * - Groups results by parent_id
- * - Returns parent context with window snippets
+ * 하이브리드 검색(Vector + FTS)을 제공하는 서비스:
+ * - 기존 인터페이스 유지 (하위 호환성)
+ * - 내부적으로 HybridSearchService 사용
+ * - Vector Search + Full-Text Search + RRF 결합
  */
 @Injectable()
 export class RagSearchService {
   private readonly logger = new Logger(RagSearchService.name);
 
-  // Dense Summary + Contextual Header 적용 후 유사도가 높아지므로
-  // threshold를 0.4로 상향 조정 (기존 0.0 → 0.4)
-  // 환경 변수로 미세 조정 가능
-  private readonly SIMILARITY_THRESHOLD = parseFloat(
-    process.env.SIMILARITY_THRESHOLD || '0.4',
-  );
-
-  private readonly CHILD_SEARCH_MULTIPLIER = (() => {
-    const value = parseInt(process.env.RAG_CHILD_SEARCH_MULTIPLIER || '3', 10);
-    return Number.isFinite(value) && value > 0 ? value : 3;
-  })();
-
-  private readonly WINDOW_CONTEXT_CHARS = parseInt(
-    process.env.RAG_WINDOW_CONTEXT_CHARS || '150',
-    10,
-  );
-
-  private readonly DEBUG_LOGS = process.env.RAG_DEBUG_LOGS === 'true';
-
-  constructor(private readonly prisma: PrismaService) {}
+  constructor(private readonly hybridSearchService: RagHybridSearchService) {}
 
   /**
-   * Search PGVector for similar conversations using Parent-Child structure
+   * Search PGVector for similar conversations using Hybrid Search
    *
-   * Strategy:
-   * 1. Search child vectors for similarity
-   * 2. Group by parent_id to avoid duplicate contexts
-   * 3. Fetch parent text for each matched parent
-   * 4. Return window context around child match
+   * 기존 메서드 시그니처 유지 (하위 호환성)
+   * 내부적으로 하이브리드 검색(Vector + FTS + RRF) 사용
+   *
+   * @param wardId 어르신 ID
+   * @param queryEmbedding 쿼리 임베딩 벡터
+   * @param limit 반환할 최대 결과 수
+   * @param query 사용자 쿼리 (선택적, FTS에 사용)
    */
   async searchPGVector(
     wardId: string,
     queryEmbedding: number[],
     limit: number,
+    query?: string,
   ): Promise<SearchResult[]> {
     try {
-      const embeddingStr = JSON.stringify(queryEmbedding);
-      const expandedLimit = Math.max(limit, limit * this.CHILD_SEARCH_MULTIPLIER);
-      this.debug(
-        `Executing PGVector query: ward=${wardId.substring(0, 8)}..., limit=${expandedLimit}`,
+      // 하이브리드 검색 실행
+      // query가 없으면 빈 문자열 전달 (벡터 검색만 수행)
+      const results = await this.hybridSearchService.search(
+        wardId,
+        query || '',
+        queryEmbedding,
+        limit,
       );
 
-      // Step 1: Search child vectors and join with parent
-      const childResults = await this.prisma.$queryRaw<
-        Array<{
-          child_id: string;
-          child_text: string;
-          parent_id: string;
-          parent_text: string;
-          offset_start: number;
-          offset_end: number;
-          metadata: RagMetadata;
-          similarity: number;
-          created_at: Date;
-          call_id: string;
-        }>
-      >(
-        Prisma.sql`
-          SELECT
-            c.id AS child_id,
-            c.child_text,
-            c.parent_id,
-            p.parent_text,
-            c.offset_start,
-            c.offset_end,
-            c.metadata,
-            1 - (c.embedding <=> ${embeddingStr}::vector) AS similarity,
-            c.created_at,
-            c.call_id
-          FROM conversation_vectors_child c
-          INNER JOIN conversation_vectors_parent p ON c.parent_id = p.id
-          WHERE c.ward_id = ${wardId}::uuid
-          ORDER BY c.embedding <=> ${embeddingStr}::vector
-          LIMIT ${expandedLimit}
-        `,
-      );
-
-      this.debug(
-        `Found ${childResults.length} child results from PGVector`,
-      );
-
-      // Filter by similarity threshold
-      const filtered = childResults.filter(
-        r => r.similarity >= this.SIMILARITY_THRESHOLD,
-      );
-
-      if (filtered.length < childResults.length) {
-        this.debug(
-          `Filtered ${childResults.length - filtered.length} child results below threshold ${this.SIMILARITY_THRESHOLD}`,
-        );
-      }
-
-      // Step 2: Group by parent_id (take highest similarity child per parent)
-      const groupedByParent = new Map<string, (typeof filtered)[0]>();
-
-      for (const result of filtered) {
-        const existing = groupedByParent.get(result.parent_id);
-        if (!existing || result.similarity > existing.similarity) {
-          groupedByParent.set(result.parent_id, result);
-        }
-      }
-
-      // Step 3: Take top N unique parents
-      const uniqueParents = Array.from(groupedByParent.values())
-        .sort((a, b) => b.similarity - a.similarity)
-        .slice(0, limit);
-
-      this.debug(
-        `Grouped ${filtered.length} child results into ${uniqueParents.length} unique parents`,
-      );
-
-      if (uniqueParents.length > 0) {
-        this.debug(
-          `Top result: similarity=${uniqueParents[0].similarity.toFixed(3)}, text="${uniqueParents[0].child_text.substring(0, 50)}..."`,
-        );
-      }
-
-      // Step 4: Build SearchResult with parent context and snippet
-      return uniqueParents.map(r => {
-        // Generate window context around the child chunk
-        const snippet = getWindowContext(
-          r.parent_text,
-          r.offset_start,
-          r.offset_end,
-          this.WINDOW_CONTEXT_CHARS,
-        );
-
-        return {
-          text: snippet || r.parent_text, // Use snippet if available, fallback to full parent
-          childText: r.child_text,
-          parentText: r.parent_text,
-          parentId: r.parent_id,
-          snippet: snippet,
-          offsetStart: r.offset_start,
-          offsetEnd: r.offset_end,
-          metadata: r.metadata,
-          similarity: r.similarity,
-          createdAt: r.created_at.toISOString(),
-          callId: r.call_id,
-        };
-      });
+      return results;
     } catch (error) {
-      this.logger.error(
-        `PGVector search failed: ${error.message}`,
-        error.stack,
-      );
+      this.logger.error(`Hybrid search failed: ${error.message}`, error.stack);
       throw error;
-    }
-  }
-
-  private debug(message: string): void {
-    if (this.DEBUG_LOGS) {
-      this.logger.debug(message);
     }
   }
 }

--- a/src/ai/rag/rag.utils.ts
+++ b/src/ai/rag/rag.utils.ts
@@ -51,6 +51,19 @@ export function cosineSimilarity(a: number[], b: number[]): number {
 }
 
 /**
+ * Validate embedding vector (non-empty, finite numbers).
+ */
+export function isValidEmbedding(
+  embedding: number[] | null | undefined,
+): embedding is number[] {
+  if (!embedding || !Array.isArray(embedding) || embedding.length === 0) {
+    return false;
+  }
+
+  return embedding.every(value => Number.isFinite(value));
+}
+
+/**
  * Child chunk configuration
  */
 export interface ChildChunk {


### PR DESCRIPTION
🚀 개요
기존 벡터 검색(Semantic Search)의 한계인 키워드 매칭 취약성을 해결하기 위해 PostgreSQL의 **Full-Text Search(FTS)**를 결합한 하이브리드 검색 엔진을 구축했습니다. 또한, 서로 다른 검색 결과를 과학적으로 병합하기 위해 RRF(Reciprocal Rank Fusion) 알고리즘을 도입하고, 검색 로직을 레이어별로 분리하여 유지보수성을 강화했습니다.

🧠 주요 변경 사항
1. 하이브리드 검색 아키텍처 도입
단순 벡터 검색에서 벗어나 **의미(Vector)와 키워드(FTS)**를 동시에 고려하는 이중 검색 체계를 구축했습니다.

병렬 실행: RagHybridSearchService에서 벡터와 FTS 검색을 Promise.all로 처리하여 응답 지연을 최소화했습니다.

검색 확장: 검색 정확도를 높이기 위해 내부적으로 검색 범위를 확장(SEARCH_EXPANSION_FACTOR=2)하여 더 많은 후보군을 검토합니다.

2. RRF(Reciprocal Rank Fusion) 기반 결과 융합
두 검색 방식의 순위를 기반으로 최종 랭킹을 산출합니다.

RRF 알고리즘: 상호 순위 융합을 통해 벡터 점수가 낮더라도 키워드가 일치하면 상위권으로 재정렬합니다.

Zero-Result Fallback: 벡터 결과가 전혀 없을 때도 FTS 결과(키워드 기반 추천)를 반환하여 에이전트의 답변 공백을 방지합니다.

디버깅 강화: 결과 메타데이터에 rrfScore, vectorRank, ftsRank를 포함하여 랭킹 로직을 추적 가능하게 했습니다.

3. PostgreSQL FTS 최적화 (DB Schema)
가중치 부여: chunk_header(날짜, 관계 정보)에 가중치 **A(High)**를, child_text에 가중치 C를 부여하여 핵심 메타데이터의 검색 중요도를 높였습니다.

Prefix OR 쿼리: 한국어 복합어 및 부분 일치 검색 성능을 높이기 위해 k:* | k2:* 형태의 검색 쿼리 변환 로직을 적용했습니다.

성능 인덱스: fts_tokens 컬럼에 GIN 인덱스를 생성하여 대량 데이터 검색 속도를 확보했습니다.

4. 아키텍처 리팩터링 (SRP 강화)
비대해진 RagSearchService를 역할에 따라 3개의 레이어로 분리했습니다.

RagSearchRepository: DB 쿼리 및 스니펫 생성 전담 (Data Access)

RagRankFusionService: RRF 알고리즘 및 중복 제거 전담 (Logic)

RagHybridSearchService: 병렬 쿼리 및 오케스트레이션 전담 (Coordination)

5. 캐시 및 성능 최적화
레거시 제거: 구버전(v1) Redis 키 지원을 종료하고 v2 중심의 단순하고 빠른 캐시 흐름을 정착시켰습니다.

인덱싱 카운트 정교화: 요약 결과의 실제 청크 수를 기반으로 인덱싱 완료 로그를 남기도록 수정했습니다.

Close : #121 