### PR TITLE
[Fix] 대상자 등록 데이터 누락 및 미연동 대상자 관리 제한 수정

### DIFF
--- a/src/admin/admin.module.ts
+++ b/src/admin/admin.module.ts
@@ -5,6 +5,7 @@ import { AdminAuthController } from './auth/admin-auth.controller';
 import { AdminAuthService } from './auth/admin-auth.service';
 import { DashboardController } from './dashboard/dashboard.controller';
 import { WardsManagementController } from './wards-management/wards-management.controller';
+import { WardsManagementService } from './wards-management/wards-management.service';
 import { LocationsController } from './locations/locations.controller';
 import { EmergenciesController } from './emergencies/emergencies.controller';
 import { BeneficiariesController } from './beneficiaries/beneficiaries.controller';
@@ -39,10 +40,17 @@ import { CsvHeaderMatcherService } from './wards-management/csv-header-matcher.s
     CallsService,
     AdminOrganizationGuard,
     CsvHeaderMatcherService,
+    WardsManagementService,
     StaffService,
     SettingsService,
     BulletinsService,
   ],
-  exports: [AdminAuthService, StaffService, SettingsService, BulletinsService],
+  exports: [
+    AdminAuthService,
+    StaffService,
+    SettingsService,
+    BulletinsService,
+    WardsManagementService,
+  ],
 })
 export class AdminModule {}

--- a/src/admin/wards-management/dto/bulk-upload-wards.dto.ts
+++ b/src/admin/wards-management/dto/bulk-upload-wards.dto.ts
@@ -1,9 +1,13 @@
 import { Transform } from 'class-transformer';
-import { IsNotEmpty, IsString } from 'class-validator';
+import { IsNotEmpty, IsOptional, IsString } from 'class-validator';
 
 export class BulkUploadWardsDto {
   @IsString()
   @IsNotEmpty()
   @Transform(({ value }) => (typeof value === 'string' ? value.trim() : value))
   organizationId!: string;
+
+  @IsOptional()
+  headerMapping?: string; // JSON string of HeaderMapping
 }
+

--- a/src/admin/wards-management/dto/bulk-upload-wards.dto.ts
+++ b/src/admin/wards-management/dto/bulk-upload-wards.dto.ts
@@ -8,6 +8,6 @@ export class BulkUploadWardsDto {
   organizationId!: string;
 
   @IsOptional()
-  headerMapping?: string; // JSON string of HeaderMapping
+  @IsString()
+  headerMapping?: string; // JSON string of HeaderMapping: Record<string, string>
 }
-

--- a/src/admin/wards-management/wards-management.controller.ts
+++ b/src/admin/wards-management/wards-management.controller.ts
@@ -21,6 +21,7 @@ import { CurrentAdmin } from '../../common';
 import { AdminOrganizationGuard } from '../../common/guards/admin-organization.guard';
 import { BulkUploadWardsDto, CreateWardDto, MatchCsvHeadersDto } from './dto';
 import { CsvHeaderMatcherService } from './csv-header-matcher.service';
+import { WardsManagementService } from './wards-management.service';
 
 @Controller('v1/admin')
 @UseGuards(AdminOrganizationGuard)
@@ -36,21 +37,8 @@ export class WardsManagementController {
   constructor(
     private readonly dbService: DbService,
     private readonly csvHeaderMatcher: CsvHeaderMatcherService,
-  ) { }
-
-  private validateWardInput(payload: Partial<CreateWardDto>) {
-    const dto = plainToInstance(CreateWardDto, payload);
-    const errors = validateSync(dto, {
-      whitelist: true,
-      forbidUnknownValues: true,
-    });
-
-    if (errors.length > 0) {
-      const constraints = errors[0].constraints;
-      const [firstError] = constraints ? Object.values(constraints) : [];
-      throw new Error(firstError || '잘못된 입력입니다.');
-    }
-  }
+    private readonly wardsManagementService: WardsManagementService,
+  ) {}
 
   @Post('wards')
   async createWard(
@@ -118,13 +106,15 @@ export class WardsManagementController {
     @Body() body: BulkUploadWardsDto,
   ) {
     const organizationId = body.organizationId;
-    const headerMapping = body.headerMapping
-      ? (JSON.parse(body.headerMapping) as Record<string, string>)
-      : null;
 
     if (!file) {
       throw new HttpException('file is required', HttpStatus.BAD_REQUEST);
     }
+
+    // JSON.parse error handling is moved to service
+    const headerMapping = this.wardsManagementService.parseHeaderMapping(
+      body.headerMapping,
+    );
 
     const maxSize = 5 * 1024 * 1024;
     if (file.size > maxSize) {
@@ -150,90 +140,12 @@ export class WardsManagementController {
         trim: true,
       }) as Array<Record<string, string>>;
 
-      const results = {
-        total: records.length,
-        created: 0,
-        skipped: 0,
-        failed: 0,
-        errors: [] as Array<{ row: number; email: string; reason: string }>,
-      };
-
-      for (let i = 0; i < records.length; i++) {
-        const record = records[i];
-        const row = i + 2;
-
-        // Extract fields using header mapping if available
-        const getField = (fieldName: string) => {
-          if (!headerMapping) return record[fieldName];
-          const actualHeader = Object.keys(headerMapping).find(
-            key => headerMapping[key] === fieldName,
-          );
-          return actualHeader ? record[actualHeader] : record[fieldName];
-        };
-
-        const email = getField('email')?.trim() ?? '';
-        const phoneNumber = getField('phone_number')?.trim() ?? '';
-        const name = getField('name')?.trim() ?? '';
-        const birthDate = getField('birth_date')?.trim() || null;
-        const address = getField('address')?.trim() || null;
-        const notes = getField('notes')?.trim() || undefined;
-
-        try {
-          this.validateWardInput({
-            organizationId,
-            email,
-            phone_number: phoneNumber,
-            name,
-            birth_date: birthDate ?? undefined,
-            address: address ?? undefined,
-            gender: getField('gender')?.trim() || undefined,
-            diseases:
-              getField('diseases')
-                ?.split(',')
-                .map((s: string) => s.trim())
-                .filter(Boolean) || undefined,
-            medication: getField('medication')?.trim() || undefined,
-            emergency_contact: getField('emergency_contact')?.trim() || undefined,
-            notes,
-          });
-
-          const existing = await this.dbService.findOrganizationWard(
-            organizationId,
-            email,
-          );
-          if (existing) {
-            results.skipped++;
-            continue;
-          }
-
-          await this.dbService.createOrganizationWard({
-            organizationId,
-            email,
-            phoneNumber,
-            name,
-            birthDate,
-            address,
-            gender: getField('gender')?.trim() || undefined,
-            diseases: getField('diseases')
-              ?.split(',')
-              .map((s: string) => s.trim())
-              .filter(Boolean),
-            medication: getField('medication')?.trim() || undefined,
-            emergencyContact: getField('emergency_contact')?.trim() || undefined,
-            uploadedByAdminId: admin.sub,
-            notes,
-          });
-
-          results.created++;
-        } catch (error) {
-          results.failed++;
-          results.errors.push({
-            row,
-            email,
-            reason: (error as Error).message,
-          });
-        }
-      }
+      const results = await this.wardsManagementService.processBulkUpload(
+        admin.sub,
+        organizationId,
+        records,
+        headerMapping,
+      );
 
       this.logger.log(
         `bulkUploadWards completed organizationId=${organizationId} adminId=${admin.sub} total=${results.total} created=${results.created} skipped=${results.skipped} failed=${results.failed}`,
@@ -247,6 +159,11 @@ export class WardsManagementController {
       this.logger.error(
         `bulkUploadWards failed error=${(error as Error).message}`,
       );
+
+      if (error instanceof HttpException) {
+        throw error;
+      }
+
       throw new HttpException(
         'Failed to process CSV file',
         HttpStatus.BAD_REQUEST,

--- a/src/admin/wards-management/wards-management.controller.ts
+++ b/src/admin/wards-management/wards-management.controller.ts
@@ -36,7 +36,7 @@ export class WardsManagementController {
   constructor(
     private readonly dbService: DbService,
     private readonly csvHeaderMatcher: CsvHeaderMatcherService,
-  ) {}
+  ) { }
 
   private validateWardInput(payload: Partial<CreateWardDto>) {
     const dto = plainToInstance(CreateWardDto, payload);
@@ -101,7 +101,7 @@ export class WardsManagementController {
       gender: created.gender,
       diseases: created.diseases,
       medication: created.medication,
-      emergencyContact: created.emergency_contact,
+      guardian: created.emergency_contact, // Standardized as guardian
       notes: created.notes,
       isRegistered: created.is_registered,
       wardId: created.ward_id,
@@ -118,6 +118,9 @@ export class WardsManagementController {
     @Body() body: BulkUploadWardsDto,
   ) {
     const organizationId = body.organizationId;
+    const headerMapping = body.headerMapping
+      ? (JSON.parse(body.headerMapping) as Record<string, string>)
+      : null;
 
     if (!file) {
       throw new HttpException('file is required', HttpStatus.BAD_REQUEST);
@@ -137,7 +140,7 @@ export class WardsManagementController {
     }
 
     this.logger.log(
-      `bulkUploadWards organizationId=${organizationId} adminId=${admin.sub} fileSize=${file.size}`,
+      `bulkUploadWards organizationId=${organizationId} adminId=${admin.sub} fileSize=${file.size} hasMapping=${!!headerMapping}`,
     );
 
     try {
@@ -145,14 +148,7 @@ export class WardsManagementController {
         columns: true,
         skip_empty_lines: true,
         trim: true,
-      }) as Array<{
-        email?: string;
-        phone_number?: string;
-        name?: string;
-        birth_date?: string;
-        address?: string;
-        notes?: string;
-      }>;
+      }) as Array<Record<string, string>>;
 
       const results = {
         total: records.length,
@@ -165,12 +161,22 @@ export class WardsManagementController {
       for (let i = 0; i < records.length; i++) {
         const record = records[i];
         const row = i + 2;
-        const email = record.email?.trim() ?? '';
-        const phoneNumber = record.phone_number?.trim() ?? '';
-        const name = record.name?.trim() ?? '';
-        const birthDate = record.birth_date?.trim() || null;
-        const address = record.address?.trim() || null;
-        const notes = record.notes?.trim() || undefined;
+
+        // Extract fields using header mapping if available
+        const getField = (fieldName: string) => {
+          if (!headerMapping) return record[fieldName];
+          const actualHeader = Object.keys(headerMapping).find(
+            key => headerMapping[key] === fieldName,
+          );
+          return actualHeader ? record[actualHeader] : record[fieldName];
+        };
+
+        const email = getField('email')?.trim() ?? '';
+        const phoneNumber = getField('phone_number')?.trim() ?? '';
+        const name = getField('name')?.trim() ?? '';
+        const birthDate = getField('birth_date')?.trim() || null;
+        const address = getField('address')?.trim() || null;
+        const notes = getField('notes')?.trim() || undefined;
 
         try {
           this.validateWardInput({
@@ -180,6 +186,14 @@ export class WardsManagementController {
             name,
             birth_date: birthDate ?? undefined,
             address: address ?? undefined,
+            gender: getField('gender')?.trim() || undefined,
+            diseases:
+              getField('diseases')
+                ?.split(',')
+                .map((s: string) => s.trim())
+                .filter(Boolean) || undefined,
+            medication: getField('medication')?.trim() || undefined,
+            emergency_contact: getField('emergency_contact')?.trim() || undefined,
             notes,
           });
 
@@ -199,6 +213,13 @@ export class WardsManagementController {
             name,
             birthDate,
             address,
+            gender: getField('gender')?.trim() || undefined,
+            diseases: getField('diseases')
+              ?.split(',')
+              .map((s: string) => s.trim())
+              .filter(Boolean),
+            medication: getField('medication')?.trim() || undefined,
+            emergencyContact: getField('emergency_contact')?.trim() || undefined,
             uploadedByAdminId: admin.sub,
             notes,
           });
@@ -273,6 +294,9 @@ export class WardsManagementController {
         address: w.address,
         notes: w.notes,
         gender: w.gender,
+        diseases: w.diseases,
+        medication: w.medication,
+        guardian: w.emergency_contact, // Map to guardian for frontend
         isRegistered: w.is_registered,
         wardId: w.ward_id,
         createdAt: w.created_at,

--- a/src/admin/wards-management/wards-management.service.ts
+++ b/src/admin/wards-management/wards-management.service.ts
@@ -1,0 +1,162 @@
+import { Injectable, Logger, HttpException, HttpStatus } from '@nestjs/common';
+import { DbService } from '../../database';
+import { sanitizeDiseases } from '../../common/utils/date.utils';
+import { CreateWardDto } from './dto';
+import { validateSync } from 'class-validator';
+import { plainToInstance } from 'class-transformer';
+
+@Injectable()
+export class WardsManagementService {
+  private readonly logger = new Logger(WardsManagementService.name);
+
+  constructor(private readonly dbService: DbService) {}
+
+  /**
+   * Parse header mapping JSON string with robust error handling
+   */
+  parseHeaderMapping(
+    mappingStr: string | undefined,
+  ): Record<string, string> | null {
+    if (!mappingStr || mappingStr.trim() === '') return null;
+    try {
+      const mapping = JSON.parse(mappingStr);
+      if (typeof mapping !== 'object' || mapping === null) {
+        throw new Error('Header mapping must be an object');
+      }
+      return mapping as Record<string, string>;
+    } catch (error) {
+      this.logger.error(
+        `Failed to parse header mapping: ${(error as Error).message}`,
+      );
+      throw new HttpException(
+        '헤더 매핑 정보(JSON)가 올바르지 않습니다.',
+        HttpStatus.BAD_REQUEST,
+      );
+    }
+  }
+
+  /**
+   * Extract fields from a CSV record based on header mapping
+   */
+  private getField(
+    record: Record<string, string>,
+    fieldName: string,
+    headerMapping: Record<string, string> | null,
+  ): string | undefined {
+    if (!headerMapping) return record[fieldName];
+    const actualHeader = Object.keys(headerMapping).find(
+      key => headerMapping[key] === fieldName,
+    );
+    return actualHeader ? record[actualHeader] : record[fieldName];
+  }
+
+  /**
+   * Parse diseases from a string separated by commas
+   */
+  private parseDiseases(diseasesStr: string | undefined): string[] {
+    if (!diseasesStr) return [];
+    return sanitizeDiseases(diseasesStr.split(','));
+  }
+
+  /**
+   * Validate a single ward record using CreateWardDto
+   */
+  validateWardInput(payload: Partial<CreateWardDto>) {
+    const dto = plainToInstance(CreateWardDto, payload);
+    const errors = validateSync(dto, {
+      whitelist: true,
+      forbidUnknownValues: true,
+    });
+
+    if (errors.length > 0) {
+      const constraints = errors[0].constraints;
+      const [firstError] = constraints ? Object.values(constraints) : [];
+      throw new Error(firstError || '잘못된 입력입니다.');
+    }
+    return dto;
+  }
+
+  /**
+   * Process bullk upload of wards
+   */
+  async processBulkUpload(
+    adminId: string,
+    organizationId: string,
+    records: Array<Record<string, string>>,
+    headerMapping: Record<string, string> | null,
+  ) {
+    const results = {
+      total: records.length,
+      created: 0,
+      skipped: 0,
+      failed: 0,
+      errors: [] as Array<{ row: number; email: string; reason: string }>,
+    };
+
+    for (let i = 0; i < records.length; i++) {
+      const record = records[i];
+      const row = i + 2;
+
+      const getVal = (field: string) =>
+        this.getField(record, field, headerMapping)?.trim();
+
+      const email = getVal('email') ?? '';
+      const phoneNumber = getVal('phone_number') ?? '';
+      const name = getVal('name') ?? '';
+      const birthDate = getVal('birth_date') || null;
+      const address = getVal('address') || null;
+      const notes = getVal('notes') || undefined;
+
+      try {
+        const validated = this.validateWardInput({
+          organizationId,
+          email,
+          phone_number: phoneNumber,
+          name,
+          birth_date: birthDate ?? undefined,
+          address: address ?? undefined,
+          gender: getVal('gender') || undefined,
+          diseases: this.parseDiseases(getVal('diseases')),
+          medication: getVal('medication') || undefined,
+          emergency_contact: getVal('emergency_contact') || undefined,
+          notes,
+        });
+
+        const existing = await this.dbService.findOrganizationWard(
+          organizationId,
+          validated.email,
+        );
+        if (existing) {
+          results.skipped++;
+          continue;
+        }
+
+        await this.dbService.createOrganizationWard({
+          organizationId,
+          email: validated.email,
+          phoneNumber: validated.phone_number,
+          name: validated.name,
+          birthDate: validated.birth_date ?? null,
+          address: validated.address ?? null,
+          gender: validated.gender,
+          diseases: validated.diseases,
+          medication: validated.medication,
+          emergencyContact: validated.emergency_contact,
+          uploadedByAdminId: adminId,
+          notes: validated.notes,
+        });
+
+        results.created++;
+      } catch (error) {
+        results.failed++;
+        results.errors.push({
+          row,
+          email,
+          reason: (error as Error).message,
+        });
+      }
+    }
+
+    return results;
+  }
+}

--- a/src/database/repositories/ward.repository.ts
+++ b/src/database/repositories/ward.repository.ts
@@ -108,7 +108,7 @@ type OrganizationWardWithDetail = Prisma.OrganizationWardGetPayload<{
 
 @Injectable()
 export class WardRepository {
-  constructor(private readonly prisma: PrismaService) {}
+  constructor(private readonly prisma: PrismaService) { }
 
   async create(params: {
     userId: string;
@@ -141,9 +141,9 @@ export class WardRepository {
 
   async findByGuardianId(guardianId: string): Promise<
     | (WardRow & {
-        user_nickname: string | null;
-        user_profile_image_url: string | null;
-      })
+      user_nickname: string | null;
+      user_profile_image_url: string | null;
+    })
     | undefined
   > {
     // guardian_ward_registrations를 통해 연결된 ward 조회
@@ -642,17 +642,17 @@ export class WardRepository {
     const [lastCalls, callCounts] =
       wardUserIds.length > 0
         ? await Promise.all([
-            this.prisma.call.groupBy({
-              by: ['calleeUserId'],
-              where: { calleeUserId: { in: wardUserIds }, state: 'ended' },
-              _max: { createdAt: true },
-            }),
-            this.prisma.call.groupBy({
-              by: ['calleeUserId'],
-              where: { calleeUserId: { in: wardUserIds }, state: 'ended' },
-              _count: true,
-            }),
-          ])
+          this.prisma.call.groupBy({
+            by: ['calleeUserId'],
+            where: { calleeUserId: { in: wardUserIds }, state: 'ended' },
+            _max: { createdAt: true },
+          }),
+          this.prisma.call.groupBy({
+            by: ['calleeUserId'],
+            where: { calleeUserId: { in: wardUserIds }, state: 'ended' },
+            _count: true,
+          }),
+        ])
         : [[], []];
 
     const lastCallMap = new Map(
@@ -677,8 +677,11 @@ export class WardRepository {
         name: ow.name,
         birth_date: ow.birthDate?.toISOString().split('T')[0] ?? null,
         address: ow.address,
-        notes: ow.notes ?? null,
         gender: ow.gender ?? null,
+        diseases: ow.diseases,
+        medication: ow.medication ?? null,
+        emergency_contact: ow.emergencyContact ?? null,
+        notes: ow.notes ?? null,
         is_registered: ow.isRegistered,
         ward_id: ow.wardId,
         created_at: ow.createdAt.toISOString(),
@@ -731,17 +734,17 @@ export class WardRepository {
     const [lastCalls, callCounts] =
       wardUserIds.length > 0
         ? await Promise.all([
-            this.prisma.call.groupBy({
-              by: ['calleeUserId'],
-              where: { calleeUserId: { in: wardUserIds }, state: 'ended' },
-              _max: { createdAt: true },
-            }),
-            this.prisma.call.groupBy({
-              by: ['calleeUserId'],
-              where: { calleeUserId: { in: wardUserIds }, state: 'ended' },
-              _count: true,
-            }),
-          ])
+          this.prisma.call.groupBy({
+            by: ['calleeUserId'],
+            where: { calleeUserId: { in: wardUserIds }, state: 'ended' },
+            _max: { createdAt: true },
+          }),
+          this.prisma.call.groupBy({
+            by: ['calleeUserId'],
+            where: { calleeUserId: { in: wardUserIds }, state: 'ended' },
+            _count: true,
+          }),
+        ])
         : [[], []];
 
     const lastCallMap = new Map(
@@ -758,6 +761,10 @@ export class WardRepository {
       name: string;
       birth_date: string | null;
       address: string | null;
+      gender: string | null;
+      diseases: string[];
+      medication: string | null;
+      emergency_contact: string | null;
       notes: string | null;
       is_registered: boolean;
       ward_id: string | null;
@@ -783,6 +790,10 @@ export class WardRepository {
         name: ow.name,
         birth_date: ow.birthDate?.toISOString().split('T')[0] ?? null,
         address: ow.address,
+        gender: ow.gender ?? null,
+        diseases: ow.diseases,
+        medication: ow.medication ?? null,
+        emergency_contact: ow.emergencyContact ?? null,
         notes: ow.notes ?? null,
         is_registered: ow.isRegistered,
         ward_id: ow.wardId,
@@ -1135,7 +1146,6 @@ export class WardRepository {
       where: {
         id: params.beneficiaryId,
         organizationId: params.organizationId,
-        isRegistered: true,
       },
     });
     return result.count > 0;
@@ -1150,7 +1160,6 @@ export class WardRepository {
       where: {
         id: params.beneficiaryId,
         organizationId: params.organizationId,
-        isRegistered: true,
       },
     });
     if (!existing) return null;
@@ -1215,7 +1224,6 @@ export class WardRepository {
       where: {
         id: beneficiaryId,
         organizationId,
-        isRegistered: true,
       },
       include: beneficiaryDetailInclude,
     });

--- a/src/database/repositories/ward.repository.ts
+++ b/src/database/repositories/ward.repository.ts
@@ -108,7 +108,7 @@ type OrganizationWardWithDetail = Prisma.OrganizationWardGetPayload<{
 
 @Injectable()
 export class WardRepository {
-  constructor(private readonly prisma: PrismaService) { }
+  constructor(private readonly prisma: PrismaService) {}
 
   async create(params: {
     userId: string;
@@ -141,9 +141,9 @@ export class WardRepository {
 
   async findByGuardianId(guardianId: string): Promise<
     | (WardRow & {
-      user_nickname: string | null;
-      user_profile_image_url: string | null;
-    })
+        user_nickname: string | null;
+        user_profile_image_url: string | null;
+      })
     | undefined
   > {
     // guardian_ward_registrations를 통해 연결된 ward 조회
@@ -642,17 +642,17 @@ export class WardRepository {
     const [lastCalls, callCounts] =
       wardUserIds.length > 0
         ? await Promise.all([
-          this.prisma.call.groupBy({
-            by: ['calleeUserId'],
-            where: { calleeUserId: { in: wardUserIds }, state: 'ended' },
-            _max: { createdAt: true },
-          }),
-          this.prisma.call.groupBy({
-            by: ['calleeUserId'],
-            where: { calleeUserId: { in: wardUserIds }, state: 'ended' },
-            _count: true,
-          }),
-        ])
+            this.prisma.call.groupBy({
+              by: ['calleeUserId'],
+              where: { calleeUserId: { in: wardUserIds }, state: 'ended' },
+              _max: { createdAt: true },
+            }),
+            this.prisma.call.groupBy({
+              by: ['calleeUserId'],
+              where: { calleeUserId: { in: wardUserIds }, state: 'ended' },
+              _count: true,
+            }),
+          ])
         : [[], []];
 
     const lastCallMap = new Map(
@@ -734,17 +734,17 @@ export class WardRepository {
     const [lastCalls, callCounts] =
       wardUserIds.length > 0
         ? await Promise.all([
-          this.prisma.call.groupBy({
-            by: ['calleeUserId'],
-            where: { calleeUserId: { in: wardUserIds }, state: 'ended' },
-            _max: { createdAt: true },
-          }),
-          this.prisma.call.groupBy({
-            by: ['calleeUserId'],
-            where: { calleeUserId: { in: wardUserIds }, state: 'ended' },
-            _count: true,
-          }),
-        ])
+            this.prisma.call.groupBy({
+              by: ['calleeUserId'],
+              where: { calleeUserId: { in: wardUserIds }, state: 'ended' },
+              _max: { createdAt: true },
+            }),
+            this.prisma.call.groupBy({
+              by: ['calleeUserId'],
+              where: { calleeUserId: { in: wardUserIds }, state: 'ended' },
+              _count: true,
+            }),
+          ])
         : [[], []];
 
     const lastCallMap = new Map(
@@ -1047,10 +1047,10 @@ export class WardRepository {
   }): Promise<BeneficiaryListResult> {
     const { organizationId, search, riskOnly = false, page, pageSize } = params;
 
-    // 연동 완료된(isRegistered=true) 대상자만 전체 대상자 관리에 노출
+    // List all beneficiaries (both registered and pending) for this organization.
+    // SECURITY: organizationId check is crucial here.
     const where: Prisma.OrganizationWardWhereInput = {
       organizationId,
-      isRegistered: true,
     };
     const q = search?.trim();
     if (q) {
@@ -1122,7 +1122,6 @@ export class WardRepository {
       where: {
         id: params.beneficiaryId,
         organizationId: params.organizationId,
-        isRegistered: true,
       },
       select: {
         id: true,


### PR DESCRIPTION
## 📋 변경 사항

- **리포지토리 제약 해제**: 미연동(isRegistered: false) 대상자도 상세 조회, 정보 수정, 삭제가 가능하도록 `WardRepository`의 제약을 해제했습니다.
- **데이터 누락 수정**: `getMyManagedWards`(조직별 목록) 응답 및 `bulkUploadWards` 처리 과정에서 신규 필드(`gender`, `diseases`, `medication`, `guardian`)가 누락되지 않도록 수정했습니다.
- **CSV 헤더 매칭 반영**: CSV 대량 업로드 시 LLM이 분석한 `headerMapping`을 실제 데이터 추출 과정에 적용하여, 헤더 이름에 상관없이 정확한 데이터를 가져오도록 개선했습니다.
- **필드명 표준화**: 프론트엔드 호환성을 위해 API 응답의 `emergency_contact` 필드명을 `guardian`으로 통일했습니다.

## 🔗 관련 이슈

Closes #133