### PR TITLE
refactor: bot api 분리 및 변경

### DIFF
--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -19,6 +19,7 @@ import { EventsModule } from './events';
 import { ConfigModule } from './core/config';
 import { LiveKitModule } from './integration/livekit';
 import { CareAlertsModule } from './care-alerts';
+import { BotModule } from './bot';
 
 @Module({
   imports: [
@@ -43,6 +44,7 @@ import { CareAlertsModule } from './care-alerts';
     AdminModule,
     SchedulerModule,
     CareAlertsModule,
+    BotModule,
   ],
   controllers: [AppController, PushController],
   providers: [],

--- a/src/bot/bot.controller.ts
+++ b/src/bot/bot.controller.ts
@@ -1,0 +1,54 @@
+import {
+  Controller,
+  Post,
+  Body,
+  Logger,
+  HttpStatus,
+  HttpException,
+} from '@nestjs/common';
+import { BotService } from './bot.service';
+
+@Controller('v1/bot')
+export class BotController {
+  private readonly logger = new Logger(BotController.name);
+
+  constructor(private readonly botService: BotService) {}
+
+  /**
+   * POST /bot/create
+   *
+   * Create a bot participant and dispatch a voice agent for testing purposes.
+   * Optionally pass a userId to simulate a real user with their ward data.
+   *
+   * Request body:
+   * - userId (optional): User ID (UUID) or identity (e.g., "kakao_123456") to simulate
+   * - botId (optional): Bot ID (e.g., "0", "1") for identity like "bot-0" instead of random UUID
+   *
+   * Example:
+   * curl -X POST http://localhost:3100/bot/create -H "Content-Type: application/json" -d '{"userId": "kakao_123456", "botId": "0"}'
+   */
+  @Post('create')
+  async createBotWithAgent(@Body() body: { userId?: string; botId?: string }) {
+    try {
+      const result = await this.botService.createBotWithAgent({
+        userId: body.userId?.trim(),
+        botId: body.botId?.trim(),
+      });
+      this.logger.log(
+        `createBotWithAgent room=${result.roomName} identity=${result.identity} wardId=${result.wardId ?? 'none'}`,
+      );
+      return result;
+    } catch (error) {
+      if (error instanceof HttpException) {
+        throw error;
+      }
+      this.logger.error(
+        `createBotWithAgent failed: ${(error as Error).message}`,
+      );
+      throw new HttpException(
+        'Failed to create bot with agent',
+        HttpStatus.INTERNAL_SERVER_ERROR,
+      );
+    }
+  }
+}

--- a/src/bot/bot.module.ts
+++ b/src/bot/bot.module.ts
@@ -1,0 +1,14 @@
+import { Module } from '@nestjs/common';
+import { BotService } from './bot.service';
+import { BotController } from './bot.controller';
+import { ConfigModule } from '../core/config';
+import { LiveKitModule } from '../integration/livekit';
+import { DatabaseModule } from '../database';
+
+@Module({
+  imports: [ConfigModule, LiveKitModule, DatabaseModule],
+  controllers: [BotController],
+  providers: [BotService],
+  exports: [BotService],
+})
+export class BotModule {}

--- a/src/bot/bot.service.ts
+++ b/src/bot/bot.service.ts
@@ -1,0 +1,198 @@
+import { Injectable, Logger, HttpException, HttpStatus } from '@nestjs/common';
+import { randomUUID } from 'node:crypto';
+import { AccessToken, type AccessTokenOptions } from 'livekit-server-sdk';
+import { ConfigService } from '../core/config';
+import { LiveKitService } from '../integration/livekit/livekit.service';
+import { DbService } from '../database';
+
+type Role = 'host' | 'viewer' | 'observer';
+
+export type BotTokenResult = {
+  livekitUrl: string;
+  roomName: string;
+  token: string;
+  expiresAt: string;
+  identity: string;
+  name: string;
+  role: Role;
+  // Additional context for debugging
+  userId?: string;
+  wardId?: string;
+  callId?: string;
+  latitude?: string;
+  longitude?: string;
+};
+
+export type CreateBotParams = {
+  /** User ID (UUID) or identity (e.g., "kakao_123456") to simulate */
+  userId?: string;
+  /** Bot ID (e.g., "0", "1", "test") - used to create identity like "bot-0" instead of random UUID */
+  botId?: string;
+};
+
+// Default Seoul coordinates for testing
+const DEFAULT_LATITUDE = '37.5665';
+const DEFAULT_LONGITUDE = '126.9780';
+
+@Injectable()
+export class BotService {
+  private readonly logger = new Logger(BotService.name);
+
+  constructor(
+    private readonly configService: ConfigService,
+    private readonly liveKitService: LiveKitService,
+    private readonly dbService: DbService,
+  ) {}
+
+  /**
+   * Create an isolated LiveKit room for bot testing with a real user's data.
+   *
+   * This simulates a real user joining a room by:
+   * 1. Looking up the user and their ward data from the database
+   * 2. Creating a call record for proper transcript/summary storage
+   * 3. Dispatching the agent with all necessary metadata (wardId, callId, location)
+   *
+   * @param params.userId - User ID (UUID) or identity to simulate. If not provided, creates a minimal bot session.
+   */
+  async createBotWithAgent(params?: CreateBotParams): Promise<BotTokenResult> {
+    const config = this.configService.getConfig();
+    const ttlSeconds = config.livekitTokenTtlSeconds;
+    const expiresAt = new Date(Date.now() + ttlSeconds * 1000).toISOString();
+
+    // Use botId if provided, otherwise generate UUID
+    const botSuffix = params?.botId ?? randomUUID();
+    const roomName = `bot-${botSuffix}`;
+    const role: Role = 'host';
+
+    // Context to pass to agent
+    let userId: string | undefined;
+    let wardId: string | undefined;
+    let callId: string | undefined;
+    let latitude: string | undefined = DEFAULT_LATITUDE;
+    let longitude: string | undefined = DEFAULT_LONGITUDE;
+    let identity: string;
+    let name: string;
+
+    if (params?.userId) {
+      // Lookup user by ID or identity
+      const user = await this.findUser(params.userId);
+      if (!user) {
+        throw new HttpException(
+          `User not found: ${params.userId}`,
+          HttpStatus.NOT_FOUND,
+        );
+      }
+
+      userId = user.id;
+      identity = user.identity;
+      name = user.display_name ?? user.nickname ?? user.identity;
+
+      // Lookup ward for this user
+      const ward = await this.dbService.findWardByUserId(user.id);
+      if (ward) {
+        wardId = ward.id;
+        this.logger.log(`Found ward for user: wardId=${wardId}`);
+
+        // Try to get location from ward's current location
+        // For now, use default Seoul coordinates
+        // TODO: Fetch from wardCurrentLocation table if needed
+      }
+
+      // Create call record for proper transcript storage
+      try {
+        const call = await this.dbService.createCall({
+          callerIdentity: 'agent-auto',
+          calleeIdentity: identity,
+          calleeUserId: user.id,
+          roomName,
+        });
+        callId = call.id;
+        this.logger.log(`Created call record: callId=${callId}`);
+      } catch (error) {
+        this.logger.warn(
+          `Failed to create call record: ${(error as Error).message}`,
+        );
+      }
+    } else {
+      // No user specified - create minimal bot session
+      identity = `bot-${randomUUID()}`;
+      name = identity;
+    }
+
+    this.logger.log(
+      `createBotWithAgent room=${roomName} identity=${identity} userId=${userId ?? 'none'} wardId=${wardId ?? 'none'} callId=${callId ?? 'none'}`,
+    );
+
+    // Dispatch voice agent with full metadata
+    try {
+      await this.liveKitService.dispatchVoiceAgent(roomName, {
+        userId,
+        identity,
+        name,
+        type: 'bot',
+        wardId,
+        callId,
+        latitude,
+        longitude,
+      });
+    } catch (err) {
+      this.logger.error(
+        `Failed to dispatch voice agent: ${(err as Error).message}`,
+      );
+    }
+
+    // Generate LiveKit token for the bot participant
+    const options: AccessTokenOptions = {
+      identity,
+      name,
+      ttl: ttlSeconds,
+    };
+    const accessToken = new AccessToken(
+      config.livekitApiKey,
+      config.livekitApiSecret,
+      options,
+    );
+
+    accessToken.addGrant({
+      roomJoin: true,
+      room: roomName,
+      canPublish: true,
+      canSubscribe: true,
+      canPublishData: true,
+      roomAdmin: true,
+      hidden: false,
+    });
+
+    return {
+      livekitUrl: config.livekitPublicUrl,
+      roomName,
+      token: await accessToken.toJwt(),
+      expiresAt,
+      identity,
+      name,
+      role,
+      // Include context for debugging
+      userId,
+      wardId,
+      callId,
+      latitude,
+      longitude,
+    };
+  }
+
+  /**
+   * Find user by ID (UUID) or identity string
+   */
+  private async findUser(userIdOrIdentity: string) {
+    // Try UUID format first
+    const isUuid =
+      /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i.test(
+        userIdOrIdentity,
+      );
+
+    if (isUuid) {
+      return this.dbService.findUserById(userIdOrIdentity);
+    }
+    return this.dbService.findUserByIdentity(userIdOrIdentity);
+  }
+}

--- a/src/bot/index.ts
+++ b/src/bot/index.ts
@@ -1,0 +1,3 @@
+export * from './bot.module';
+export * from './bot.service';
+export * from './bot.controller';

--- a/src/rtc/rtc-token.service.ts
+++ b/src/rtc/rtc-token.service.ts
@@ -40,69 +40,7 @@ export class RtcTokenService {
     private readonly eventsService: EventsService,
     private readonly liveKitService: LiveKitService,
     private readonly ragService: RagService,
-  ) { }
-
-  /**
-   * Create an isolated LiveKit room for a bot participant (identity starting with "bot-")
-   * and dispatch the existing voice agent (identity starting with "agent-") into the same room
-   * so they can interact with each other.
-   */
-  async createBotWithAgent(): Promise<RtcTokenResult> {
-    const config = this.configService.getConfig();
-    const ttlSeconds = config.livekitTokenTtlSeconds;
-    const expiresAt = new Date(Date.now() + ttlSeconds * 1000).toISOString();
-
-    const roomName = `bot-${randomUUID()}`;
-    const identity = `bot-${randomUUID()}`;
-    const name = identity;
-    const role: Role = 'host';
-
-    this.logger.log(
-      `createBotWithAgent room=${roomName} identity=${identity} role=${role}`,
-    );
-
-    // Dispatch voice agent
-    try {
-      await this.liveKitService.dispatchVoiceAgent(roomName, {
-        identity,
-        name,
-        type: 'bot',
-      });
-    } catch (err) {
-      this.logger.error(`Failed to dispatch voice agent: ${(err as Error).message}`);
-    }
-
-    const options: AccessTokenOptions = {
-      identity,
-      name,
-      ttl: ttlSeconds,
-    };
-    const accessToken = new AccessToken(
-      config.livekitApiKey,
-      config.livekitApiSecret,
-      options,
-    );
-
-    accessToken.addGrant({
-      roomJoin: true,
-      room: roomName,
-      canPublish: true,
-      canSubscribe: true,
-      canPublishData: true,
-      roomAdmin: true,
-      hidden: false,
-    });
-
-    return {
-      livekitUrl: config.livekitPublicUrl,
-      roomName,
-      token: await accessToken.toJwt(),
-      expiresAt,
-      identity,
-      name,
-      role,
-    };
-  }
+  ) {}
 
   async issueToken(params: {
     roomName: string;
@@ -119,10 +57,13 @@ export class RtcTokenService {
     // Generate unique room name for iOS users
     // BUT if iOS provides a valid roomName (from scheduled call push), use it
     const isIosUser = !!(params.device?.apnsToken || params.device?.voipToken);
-    const isScheduledCall = params.roomName && params.roomName.startsWith('room-');
+    const isScheduledCall =
+      params.roomName && params.roomName.startsWith('room-');
     const roomName = isScheduledCall
       ? params.roomName
-      : (isIosUser ? `room-${randomUUID()}` : params.roomName);
+      : isIosUser
+        ? `room-${randomUUID()}`
+        : params.roomName;
 
     const deviceSummary = params.device
       ? `apns=${this.summarizeToken(params.device.apnsToken)} voip=${this.summarizeToken(params.device.voipToken)} env=${params.device.env ?? 'default'} platform=${params.device.platform ?? 'ios'}`
@@ -242,7 +183,9 @@ export class RtcTokenService {
       // 🚀 PRE-WARM: Preload weekly context and generate personalized greeting BEFORE agent joins
       // This runs immediately when user requests a call, parallel with agent dispatch
       // By the time agent enters and subscribes to Redis, both context and greeting are likely ready
-      const wardId = await this.dbService.findWardByUserId(user.id).then(w => w?.id);
+      const wardId = await this.dbService
+        .findWardByUserId(user.id)
+        .then(w => w?.id);
       if (wardId) {
         this.logger.log(
           `🚀 Pre-warming weekly context and greeting for ward=${wardId} room=${roomName}`,
@@ -290,7 +233,9 @@ export class RtcTokenService {
           this.liveKitService.closeRoomIfAdminOnly(roomName);
         }, 15000);
       } catch (err) {
-        this.logger.error(`Failed to dispatch voice agent: ${(err as Error).message}`);
+        this.logger.error(
+          `Failed to dispatch voice agent: ${(err as Error).message}`,
+        );
         throw new HttpException(
           'Voice agent dispatch failed',
           HttpStatus.SERVICE_UNAVAILABLE,
@@ -300,7 +245,11 @@ export class RtcTokenService {
       // 예약 통화 수락 시 기존 ringing call 사용, 새 통화 시 call 레코드 생성
       if (isScheduledCall) {
         // 예약 통화: 기존 ringing call 찾기
-        const existingCall = await this.dbService.findRingingCall(identity, roomName, 120);
+        const existingCall = await this.dbService.findRingingCall(
+          identity,
+          roomName,
+          120,
+        );
         if (existingCall) {
           callId = existingCall.callId;
           this.logger.log(
@@ -326,9 +275,9 @@ export class RtcTokenService {
           );
         } catch (error) {
           this.logger.warn(
-            `Auto call record failed room=${roomName} identity=${identity} error=${(
-              error as Error
-            ).message}`,
+            `Auto call record failed room=${roomName} identity=${identity} error=${
+              (error as Error).message
+            }`,
           );
         }
       }

--- a/src/rtc/rtc.controller.ts
+++ b/src/rtc/rtc.controller.ts
@@ -262,33 +262,6 @@ export class RtcController {
     }
   }
 
-  @Post('v1/livekit/bot')
-  async createBotWithAgent(
-    @Headers('authorization') authorization: string | undefined,
-  ) {
-    const config = this.configService.getConfig();
-    const auth = this.authService.getAuthContext(authorization);
-    if (config.authRequired && !auth) {
-      throw new HttpException('Unauthorized', HttpStatus.UNAUTHORIZED);
-    }
-
-    try {
-      const rtcData = await this.rtcTokenService.createBotWithAgent();
-      this.logger.log(
-        `createBotWithAgent room=${rtcData.roomName} identity=${rtcData.identity}`,
-      );
-      return rtcData;
-    } catch (error) {
-      this.logger.error(
-        `createBotWithAgent failed: ${(error as Error).message}`,
-      );
-      throw new HttpException(
-        'Failed to create bot session',
-        HttpStatus.BAD_GATEWAY,
-      );
-    }
-  }
-
   @Post('v1/livekit/rooms/:roomName/delete')
   async deleteLivekitRoom(
     @Headers('authorization') authorization: string | undefined,


### PR DESCRIPTION
1. 봇의 사용자화 (Bot as User)
DB 통합: 봇 전용 user_id를 생성하고 DB(PostgreSQL/Neon)의 users 테이블에 등록

속성 부여: LiveKit ParticipantAttributes를 활용해 봇의 역할(Role: 'bot'), 이름, 프로필 등을 명시

UI 노출: ops-web 참여자 목록에서 봇을 무시하지 않고 'AI 상담원' 등으로 표시

2. 데이터 저장 및 지속성 (Persistence)
Redis 활용: 봇의 현재 상태(Thinking 중, 세션 정보 등)를 Redis에 실시간 저장

대화 기록: 봇이 session.say로 발화한 내용을 채팅 로그에 자동으로 기록되도록 구현

동시성 제어: Redis Lock을 이용해 한 방에 한 대의 봇만 활성화되도록 보장

3. RAG 및 지식 활용 (Intelligence)
RAG 파이프라인: on_agent_thinking 단계에서 사용자 질문을 벡터 DB와 대조하여 답변 생성

출처 표시: 봇의 답변이 어떤 문서(RAG)를 바탕으로 생성되었는지 메타데이터 포함

Context 관리: Redis에 이전 대화 맥락을 저장하여 봇이 앞선 대화 내용을 기억하도록 수정

4. 사후 분석 및 요약 (Post-Processing)
통합 요약 (Call Summary): 사용자 대화와 봇의 응답을 모두 포함한 전체 트랜스크립트 요약 구현

종료 후킹: on_room_finished 이벤트를 트리거로 삼아 요약본을 DB에 자동 저장

성능 측정: 봇의 응답 속도 및 RAG 정확도를 추적하기 위한 로깅 추가