### PR TITLE
feat(api): beneficiary call schedule integration

### DIFF
--- a/src/admin/beneficiaries/beneficiaries.controller.ts
+++ b/src/admin/beneficiaries/beneficiaries.controller.ts
@@ -35,6 +35,11 @@ import {
   TransformEmptyToUndefined,
 } from '../../common';
 import type { BeneficiaryListItem } from '../../database/repositories/ward.repository';
+import {
+  UpdateBeneficiaryScheduleDto,
+  BeneficiaryScheduleResponse,
+} from './beneficiary-schedule.dto';
+import { SettingsService } from '../settings/settings.service';
 
 class ListBeneficiariesQueryDto {
   @IsOptional()
@@ -169,6 +174,7 @@ export class BeneficiariesController {
   constructor(
     private readonly dbService: DbService,
     private readonly staffService: StaffService,
+    private readonly settingsService: SettingsService,
   ) {}
 
   @Get()
@@ -239,6 +245,82 @@ export class BeneficiariesController {
         averageDurationMinutes: stats.averageDurationMinutes,
       },
       callDates: stats.callDates,
+    };
+  }
+
+  @Get(':id/schedule')
+  async getSchedule(
+    @CurrentAdmin() admin: { organization_id?: string },
+    @Param('id', new ParseUUIDPipe()) id: string,
+  ): Promise<BeneficiaryScheduleResponse> {
+    const organizationId = this.getOrganizationId(admin);
+
+    const scheduleData = await this.dbService.getBeneficiarySchedule({
+      organizationId,
+      beneficiaryId: id,
+    });
+
+    if (!scheduleData) {
+      throw new HttpException(
+        '대상자 정보를 찾을 수 없습니다.',
+        HttpStatus.NOT_FOUND,
+      );
+    }
+
+    // Get organization service hours
+    const settings = await this.settingsService.getSettings(organizationId);
+
+    return {
+      beneficiaryId: id,
+      schedule: scheduleData.schedule,
+      organizationServiceHours: {
+        startTime: settings.preferredStartTime,
+        endTime: settings.preferredEndTime,
+      },
+      updatedAt: scheduleData.updatedAt,
+    };
+  }
+
+  @Put(':id/schedule')
+  async updateSchedule(
+    @CurrentAdmin() admin: { organization_id?: string },
+    @Param('id', new ParseUUIDPipe()) id: string,
+    @Body() body: UpdateBeneficiaryScheduleDto,
+  ): Promise<BeneficiaryScheduleResponse> {
+    const organizationId = this.getOrganizationId(admin);
+
+    const scheduleData = await this.dbService.updateBeneficiarySchedule({
+      organizationId,
+      beneficiaryId: id,
+      schedule: {
+        sunday: body.sunday,
+        monday: body.monday,
+        tuesday: body.tuesday,
+        wednesday: body.wednesday,
+        thursday: body.thursday,
+        friday: body.friday,
+        saturday: body.saturday,
+      },
+    });
+
+    if (!scheduleData) {
+      throw new HttpException(
+        '대상자 정보를 찾을 수 없습니다.',
+        HttpStatus.NOT_FOUND,
+      );
+    }
+
+    // Get organization service hours
+    const settings = await this.settingsService.getSettings(organizationId);
+
+    return {
+      beneficiaryId: id,
+      schedule: scheduleData.schedule,
+      organizationServiceHours: {
+        startTime: settings.preferredStartTime,
+        endTime: settings.preferredEndTime,
+      },
+      updatedAt: scheduleData.updatedAt,
     };
   }
 

--- a/src/admin/beneficiaries/beneficiary-schedule.dto.ts
+++ b/src/admin/beneficiaries/beneficiary-schedule.dto.ts
@@ -1,0 +1,100 @@
+import { IsOptional, IsString, Matches } from 'class-validator';
+import { Transform } from 'class-transformer';
+
+// Time format regex: HH:mm (00:00 - 23:59)
+const TIME_REGEX = /^([01]\d|2[0-3]):([0-5]\d)$/;
+
+/**
+ * DTO for updating beneficiary call schedule
+ * Each day can be a time string (HH:mm) or null (no schedule)
+ */
+export class UpdateBeneficiaryScheduleDto {
+  @IsOptional()
+  @Transform(({ value }) => (value === '' ? null : value))
+  @IsString()
+  @Matches(TIME_REGEX, { message: 'sunday must be in HH:mm format' })
+  sunday?: string | null;
+
+  @IsOptional()
+  @Transform(({ value }) => (value === '' ? null : value))
+  @IsString()
+  @Matches(TIME_REGEX, { message: 'monday must be in HH:mm format' })
+  monday?: string | null;
+
+  @IsOptional()
+  @Transform(({ value }) => (value === '' ? null : value))
+  @IsString()
+  @Matches(TIME_REGEX, { message: 'tuesday must be in HH:mm format' })
+  tuesday?: string | null;
+
+  @IsOptional()
+  @Transform(({ value }) => (value === '' ? null : value))
+  @IsString()
+  @Matches(TIME_REGEX, { message: 'wednesday must be in HH:mm format' })
+  wednesday?: string | null;
+
+  @IsOptional()
+  @Transform(({ value }) => (value === '' ? null : value))
+  @IsString()
+  @Matches(TIME_REGEX, { message: 'thursday must be in HH:mm format' })
+  thursday?: string | null;
+
+  @IsOptional()
+  @Transform(({ value }) => (value === '' ? null : value))
+  @IsString()
+  @Matches(TIME_REGEX, { message: 'friday must be in HH:mm format' })
+  friday?: string | null;
+
+  @IsOptional()
+  @Transform(({ value }) => (value === '' ? null : value))
+  @IsString()
+  @Matches(TIME_REGEX, { message: 'saturday must be in HH:mm format' })
+  saturday?: string | null;
+}
+
+/**
+ * Schedule response with day-wise time slots
+ */
+export interface BeneficiaryScheduleResponse {
+  beneficiaryId: string;
+  schedule: {
+    sunday: string | null;
+    monday: string | null;
+    tuesday: string | null;
+    wednesday: string | null;
+    thursday: string | null;
+    friday: string | null;
+    saturday: string | null;
+  };
+  organizationServiceHours: {
+    startTime: string;
+    endTime: string;
+  };
+  updatedAt: string;
+}
+
+/**
+ * Day of week mapping
+ * 0 = Sunday, 1 = Monday, ..., 6 = Saturday
+ */
+export const DAY_OF_WEEK_MAP = {
+  sunday: 0,
+  monday: 1,
+  tuesday: 2,
+  wednesday: 3,
+  thursday: 4,
+  friday: 5,
+  saturday: 6,
+} as const;
+
+export type DayName = keyof typeof DAY_OF_WEEK_MAP;
+
+export const DAY_NAMES: DayName[] = [
+  'sunday',
+  'monday',
+  'tuesday',
+  'wednesday',
+  'thursday',
+  'friday',
+  'saturday',
+];

--- a/src/database/db.service.ts
+++ b/src/database/db.service.ts
@@ -763,6 +763,29 @@ export class DbService implements OnModuleDestroy {
     return this.wards.getOrganizationBeneficiaryDetail(params);
   }
 
+  async getBeneficiarySchedule(params: {
+    organizationId: string;
+    beneficiaryId: string;
+  }) {
+    return this.wards.getBeneficiarySchedule(params);
+  }
+
+  async updateBeneficiarySchedule(params: {
+    organizationId: string;
+    beneficiaryId: string;
+    schedule: {
+      sunday?: string | null;
+      monday?: string | null;
+      tuesday?: string | null;
+      wednesday?: string | null;
+      thursday?: string | null;
+      friday?: string | null;
+      saturday?: string | null;
+    };
+  }) {
+    return this.wards.updateBeneficiarySchedule(params);
+  }
+
   // ============================================================
   // Admin methods
   // ============================================================

--- a/src/database/repositories/ward.repository.ts
+++ b/src/database/repositories/ward.repository.ts
@@ -1231,6 +1231,209 @@ export class WardRepository {
 
     return toBeneficiaryDetailItem(row);
   }
+
+  /**
+   * Get beneficiary call schedule
+   * Returns day-wise schedule (each day has 0 or 1 time slot)
+   */
+  async getBeneficiarySchedule(params: {
+    organizationId: string;
+    beneficiaryId: string;
+  }): Promise<BeneficiaryScheduleData | null> {
+    const { organizationId, beneficiaryId } = params;
+
+    // Get organization ward and verify it belongs to the organization
+    const orgWard = await this.prisma.organizationWard.findFirst({
+      where: {
+        id: beneficiaryId,
+        organizationId,
+      },
+      select: {
+        wardId: true,
+        updatedAt: true,
+      },
+    });
+
+    if (!orgWard) return null;
+
+    // Initialize empty schedule
+    const schedule: BeneficiaryScheduleData['schedule'] = {
+      sunday: null,
+      monday: null,
+      tuesday: null,
+      wednesday: null,
+      thursday: null,
+      friday: null,
+      saturday: null,
+    };
+
+    // If not linked to a ward, return empty schedule
+    if (!orgWard.wardId) {
+      return {
+        schedule,
+        updatedAt: orgWard.updatedAt.toISOString(),
+      };
+    }
+
+    // Get schedules from CallScheduleGroup for this ward
+    const schedules = await this.prisma.callScheduleGroup.findMany({
+      where: {
+        wardId: orgWard.wardId,
+        isEnabled: true,
+      },
+      orderBy: { updatedAt: 'desc' },
+    });
+
+    // Map schedules to day-wise format
+    // Each schedule has weekdays array [0-6], we need to extract individual days
+    const dayNames: Array<keyof BeneficiaryScheduleData['schedule']> = [
+      'sunday',
+      'monday',
+      'tuesday',
+      'wednesday',
+      'thursday',
+      'friday',
+      'saturday',
+    ];
+
+    for (const sched of schedules) {
+      const timeStr = `${sched.slotStartHour.toString().padStart(2, '0')}:${sched.slotStartMinute.toString().padStart(2, '0')}`;
+      for (const dayOfWeek of sched.weekdays) {
+        if (dayOfWeek >= 0 && dayOfWeek <= 6) {
+          const dayName = dayNames[dayOfWeek];
+          // Only set if not already set (first match wins - most recent due to orderBy)
+          if (schedule[dayName] === null) {
+            schedule[dayName] = timeStr;
+          }
+        }
+      }
+    }
+
+    // Find the most recent update time
+    const latestUpdate =
+      schedules.length > 0
+        ? schedules
+            .map(s => s.updatedAt)
+            .reduce((a, b) => (a > b ? a : b))
+            .toISOString()
+        : orgWard.updatedAt.toISOString();
+
+    return {
+      schedule,
+      updatedAt: latestUpdate,
+    };
+  }
+
+  /**
+   * Update beneficiary call schedule
+   * Replaces existing schedules with new day-wise schedule
+   */
+  async updateBeneficiarySchedule(params: {
+    organizationId: string;
+    beneficiaryId: string;
+    schedule: Partial<BeneficiaryScheduleData['schedule']>;
+  }): Promise<BeneficiaryScheduleData | null> {
+    const { organizationId, beneficiaryId, schedule } = params;
+
+    // Get organization ward and verify it belongs to the organization
+    const orgWard = await this.prisma.organizationWard.findFirst({
+      where: {
+        id: beneficiaryId,
+        organizationId,
+      },
+      select: {
+        wardId: true,
+      },
+    });
+
+    if (!orgWard) return null;
+
+    // If not linked to a ward, cannot update schedule
+    if (!orgWard.wardId) {
+      return {
+        schedule: {
+          sunday: null,
+          monday: null,
+          tuesday: null,
+          wednesday: null,
+          thursday: null,
+          friday: null,
+          saturday: null,
+        },
+        updatedAt: new Date().toISOString(),
+      };
+    }
+
+    // Delete existing schedules for this ward
+    await this.prisma.callScheduleGroup.deleteMany({
+      where: {
+        wardId: orgWard.wardId,
+      },
+    });
+
+    // Create new schedules - one record per unique time slot
+    // Group days by time slot
+    const timeSlotDays: Record<string, number[]> = {};
+    const dayNames: Array<keyof BeneficiaryScheduleData['schedule']> = [
+      'sunday',
+      'monday',
+      'tuesday',
+      'wednesday',
+      'thursday',
+      'friday',
+      'saturday',
+    ];
+
+    for (let dayOfWeek = 0; dayOfWeek < 7; dayOfWeek++) {
+      const dayName = dayNames[dayOfWeek];
+      const timeValue = schedule[dayName];
+      if (timeValue && timeValue !== null) {
+        if (!timeSlotDays[timeValue]) {
+          timeSlotDays[timeValue] = [];
+        }
+        timeSlotDays[timeValue].push(dayOfWeek);
+      }
+    }
+
+    // Create schedule records
+    const now = new Date();
+    for (const [timeStr, weekdays] of Object.entries(timeSlotDays)) {
+      const [hourStr, minuteStr] = timeStr.split(':');
+      const hour = parseInt(hourStr, 10);
+      const minute = parseInt(minuteStr, 10);
+
+      await this.prisma.callScheduleGroup.create({
+        data: {
+          wardId: orgWard.wardId,
+          slotStartHour: hour,
+          slotStartMinute: minute,
+          weekdays,
+          isEnabled: true,
+          createdAt: now,
+          updatedAt: now,
+        },
+      });
+    }
+
+    // Return updated schedule
+    return this.getBeneficiarySchedule({ organizationId, beneficiaryId });
+  }
+}
+
+/**
+ * Beneficiary schedule data structure
+ */
+export interface BeneficiaryScheduleData {
+  schedule: {
+    sunday: string | null;
+    monday: string | null;
+    tuesday: string | null;
+    wednesday: string | null;
+    thursday: string | null;
+    friday: string | null;
+    saturday: string | null;
+  };
+  updatedAt: string;
 }
 
 function toBeneficiaryDetailItem(

--- a/src/rtc/rtc-token.service.ts
+++ b/src/rtc/rtc-token.service.ts
@@ -57,8 +57,11 @@ export class RtcTokenService {
     // Generate unique room name for iOS users
     // BUT if iOS provides a valid roomName (from scheduled call push), use it
     const isIosUser = !!(params.device?.apnsToken || params.device?.voipToken);
+    // Scheduled calls have room names starting with 'room-' or 'call-'
     const isScheduledCall =
-      params.roomName && params.roomName.startsWith('room-');
+      params.roomName &&
+      (params.roomName.startsWith('room-') ||
+        params.roomName.startsWith('call-'));
     const roomName = isScheduledCall
       ? params.roomName
       : isIosUser


### PR DESCRIPTION
## [Backend] Beneficiary Call Schedule
Implemented backend support for managing and executing scheduled beneficiary calls.

### Key Changes
- **Scheduled Call Optimization**: 
  - Updated `RtcTokenService` to recognize the `call-` prefix (used by the scheduler) in addition to `room-`. 
  - This fixes a critical bug where scheduled calls were rejected with a "user already in call" error because the system didn't recognize them as valid incoming scheduled rooms.
- **Repository Improvements**:
  - Added `getBeneficiarySchedule` and `updateBeneficiarySchedule` to `WardRepository`.
  - Implemented logic to group multiple days sharing the same time into a single `CallScheduleGroup` record for efficiency.
- **API Endpoints**:
  - `GET /v1/admin/beneficiaries/:id/schedule`: Fetches current schedule and organization service hours.
  - `PUT /v1/admin/beneficiaries/:id/schedule`: Updates the schedule with validation for time formats (HH:mm).