### PR TITLE
[Fix] Stale call 정리 메커니즘 추가

### DIFF
--- a/src/database/db.service.ts
+++ b/src/database/db.service.ts
@@ -313,7 +313,7 @@ export class DbService implements OnModuleDestroy {
   /**
    * Stale call 정리: 'answered' 상태에서 maxAgeMinutes 이상 지속된 통화를 'ended'로 변경
    */
-  async endStaleCalls(maxAgeMinutes: number = 30) {
+  async endStaleCalls(maxAgeMinutes: number = 15) {
     return this.calls.endStaleCalls(maxAgeMinutes);
   }
 

--- a/src/database/db.service.ts
+++ b/src/database/db.service.ts
@@ -310,6 +310,20 @@ export class DbService implements OnModuleDestroy {
     return this.calls.getIndexingInfo(callId);
   }
 
+  /**
+   * Stale call 정리: 'answered' 상태에서 maxAgeMinutes 이상 지속된 통화를 'ended'로 변경
+   */
+  async endStaleCalls(maxAgeMinutes: number = 30) {
+    return this.calls.endStaleCalls(maxAgeMinutes);
+  }
+
+  /**
+   * roomName으로 처리되지 않은 모든 통화를 종료
+   */
+  async endCallsByRoomName(roomName: string) {
+    return this.calls.endCallsByRoomName(roomName);
+  }
+
   // ============================================================
   // Guardian methods
   // ============================================================

--- a/src/database/repositories/call.repository.ts
+++ b/src/database/repositories/call.repository.ts
@@ -438,7 +438,9 @@ export class CallRepository {
   async getFailedIndexingCalls(
     maxAttempts: number = 3,
     limit: number = 100,
-  ): Promise<Array<{ callId: string; wardId: string | null; attempts: number }>> {
+  ): Promise<
+    Array<{ callId: string; wardId: string | null; attempts: number }>
+  > {
     const calls = await this.prisma.call.findMany({
       where: {
         indexingStatus: IndexingStatus.FAILED,
@@ -496,5 +498,50 @@ export class CallRepository {
       attempts: call.indexingAttempts,
       indexedAt: call.indexedAt,
     };
+  }
+
+  /**
+   * Stale call 정리: 'answered' 상태에서 maxAgeMinutes 이상 지속된 통화를 'ended'로 변경
+   * LiveKit webhook 누락 시 안전망 역할
+   *
+   * @param maxAgeMinutes 스테일로 간주할 최소 시간 (분)
+   * @returns 종료된 통화 수
+   */
+  async endStaleCalls(maxAgeMinutes: number = 30): Promise<number> {
+    const cutoff = new Date(Date.now() - maxAgeMinutes * 60 * 1000);
+
+    const result = await this.prisma.call.updateMany({
+      where: {
+        state: 'answered',
+        answeredAt: { lt: cutoff },
+        endedAt: null,
+      },
+      data: {
+        state: 'ended',
+        endedAt: new Date(),
+      },
+    });
+
+    return result.count;
+  }
+
+  /**
+   * roomName으로 처리되지 않은 모든 통화를 종료
+   * room_finished 웹훅에서 callContext를 찾지 못했을 때 fallback으로 사용
+   */
+  async endCallsByRoomName(roomName: string): Promise<number> {
+    const result = await this.prisma.call.updateMany({
+      where: {
+        roomName,
+        state: { not: 'ended' },
+        endedAt: null,
+      },
+      data: {
+        state: 'ended',
+        endedAt: new Date(),
+      },
+    });
+
+    return result.count;
   }
 }

--- a/src/database/repositories/call.repository.ts
+++ b/src/database/repositories/call.repository.ts
@@ -505,15 +505,35 @@ export class CallRepository {
    * LiveKit webhook 누락 시 안전망 역할
    *
    * @param maxAgeMinutes 스테일로 간주할 최소 시간 (분)
-   * @returns 종료된 통화 수
+   * @returns 종료된 통화 ID 목록
    */
-  async endStaleCalls(maxAgeMinutes: number = 30): Promise<number> {
+  async endStaleCalls(
+    maxAgeMinutes: number = 15,
+  ): Promise<{ count: number; callIds: string[] }> {
     const cutoff = new Date(Date.now() - maxAgeMinutes * 60 * 1000);
 
-    const result = await this.prisma.call.updateMany({
+    // 먼저 대상 통화 조회 (로깅 및 감사용)
+    const staleCalls = await this.prisma.call.findMany({
       where: {
         state: 'answered',
-        answeredAt: { lt: cutoff },
+        endedAt: null,
+        // answeredAt이 null일 수 있으므로 createdAt 기반 OR 조건 추가
+        OR: [{ answeredAt: { lt: cutoff } }, { createdAt: { lt: cutoff } }],
+      },
+      select: { callId: true },
+    });
+
+    if (staleCalls.length === 0) {
+      return { count: 0, callIds: [] };
+    }
+
+    const callIds = staleCalls.map(c => c.callId);
+
+    // 조회된 callId 기준으로 업데이트 (race condition 방지)
+    await this.prisma.call.updateMany({
+      where: {
+        callId: { in: callIds },
+        state: 'answered', // 상태 재확인
         endedAt: null,
       },
       data: {
@@ -522,18 +542,39 @@ export class CallRepository {
       },
     });
 
-    return result.count;
+    return { count: callIds.length, callIds };
   }
 
   /**
    * roomName으로 처리되지 않은 모든 통화를 종료
    * room_finished 웹훅에서 callContext를 찾지 못했을 때 fallback으로 사용
+   *
+   * @returns 종료된 통화 ID 목록
    */
-  async endCallsByRoomName(roomName: string): Promise<number> {
-    const result = await this.prisma.call.updateMany({
+  async endCallsByRoomName(
+    roomName: string,
+  ): Promise<{ count: number; callIds: string[] }> {
+    // 먼저 대상 통화 조회 (로깅용)
+    const activeCalls = await this.prisma.call.findMany({
       where: {
         roomName,
-        state: { not: 'ended' },
+        state: { in: ['ringing', 'answered'] }, // 명시적 상태 리스트
+        endedAt: null,
+      },
+      select: { callId: true },
+    });
+
+    if (activeCalls.length === 0) {
+      return { count: 0, callIds: [] };
+    }
+
+    const callIds = activeCalls.map(c => c.callId);
+
+    // 조회된 callId 기준으로 업데이트 (race condition 방지)
+    await this.prisma.call.updateMany({
+      where: {
+        callId: { in: callIds },
+        state: { in: ['ringing', 'answered'] }, // 상태 재확인
         endedAt: null,
       },
       data: {
@@ -542,6 +583,6 @@ export class CallRepository {
       },
     });
 
-    return result.count;
+    return { count: callIds.length, callIds };
   }
 }

--- a/src/integration/livekit/livekit-webhook.controller.ts
+++ b/src/integration/livekit/livekit-webhook.controller.ts
@@ -184,9 +184,21 @@ export class LiveKitWebhookController {
                   );
                 }
               } else {
+                // Fallback: end any non-ended calls for this room
+                // This handles cases where getCallContextByRoomName returns null
                 this.logger.warn(
-                  `No call context found for room=${room.name}, skipping analysis`,
+                  `No call context found for room=${room.name}, attempting fallback cleanup`,
                 );
+                const endedCount = await this.dbService.endCallsByRoomName(
+                  room.name,
+                );
+                if (endedCount > 0) {
+                  this.logger.log(
+                    `Fallback cleanup ended ${endedCount} call(s) for room=${room.name}`,
+                  );
+                } else {
+                  this.logger.log(`No calls to cleanup for room=${room.name}`);
+                }
               }
             } catch (error) {
               this.logger.error(

--- a/src/integration/livekit/livekit-webhook.controller.ts
+++ b/src/integration/livekit/livekit-webhook.controller.ts
@@ -189,15 +189,23 @@ export class LiveKitWebhookController {
                 this.logger.warn(
                   `No call context found for room=${room.name}, attempting fallback cleanup`,
                 );
-                const endedCount = await this.dbService.endCallsByRoomName(
-                  room.name,
-                );
-                if (endedCount > 0) {
-                  this.logger.log(
-                    `Fallback cleanup ended ${endedCount} call(s) for room=${room.name}`,
+                try {
+                  const result = await this.dbService.endCallsByRoomName(
+                    room.name,
                   );
-                } else {
-                  this.logger.log(`No calls to cleanup for room=${room.name}`);
+                  if (result.count > 0) {
+                    this.logger.log(
+                      `Fallback cleanup ended ${result.count} call(s) for room=${room.name} callIds=[${result.callIds.join(', ')}]`,
+                    );
+                  } else {
+                    this.logger.log(
+                      `No calls to cleanup for room=${room.name}`,
+                    );
+                  }
+                } catch (fallbackError) {
+                  this.logger.error(
+                    `Fallback cleanup failed for room=${room.name}: ${(fallbackError as Error).message}`,
+                  );
                 }
               }
             } catch (error) {

--- a/src/scheduler/notification.scheduler.spec.ts
+++ b/src/scheduler/notification.scheduler.spec.ts
@@ -29,7 +29,7 @@ describe('NotificationScheduler', () => {
       getMissedCalls: jest.fn().mockResolvedValue([]),
       getSchedulesForCurrentSlot: jest.fn().mockResolvedValue([]),
       markReminderSent: jest.fn().mockResolvedValue(undefined),
-      endStaleCalls: jest.fn().mockResolvedValue(0),
+      endStaleCalls: jest.fn().mockResolvedValue({ count: 0, callIds: [] }),
     };
 
     mockCallsService = {
@@ -203,7 +203,10 @@ describe('NotificationScheduler', () => {
 
     it('should log when stale calls are ended', async () => {
       mockRedisClient.set.mockResolvedValue('OK');
-      (mockDbService.endStaleCalls as jest.Mock).mockResolvedValue(3);
+      (mockDbService.endStaleCalls as jest.Mock).mockResolvedValue({
+        count: 3,
+        callIds: ['call-1', 'call-2', 'call-3'],
+      });
 
       await scheduler.cleanupStaleCalls();
 

--- a/src/scheduler/notification.scheduler.spec.ts
+++ b/src/scheduler/notification.scheduler.spec.ts
@@ -5,168 +5,209 @@ import { CallsService } from '../calls/calls.service';
 
 // Mock Redis client
 const mockRedisClient = {
-    connect: jest.fn(),
-    quit: jest.fn(),
-    set: jest.fn(),
+  connect: jest.fn(),
+  quit: jest.fn(),
+  set: jest.fn(),
 };
 
 jest.mock('redis', () => ({
-    createClient: jest.fn(() => mockRedisClient),
+  createClient: jest.fn(() => mockRedisClient),
 }));
 
 describe('NotificationScheduler', () => {
-    let scheduler: NotificationScheduler;
-    let mockDbService: Partial<DbService>;
-    let mockCallsService: Partial<CallsService>;
+  let scheduler: NotificationScheduler;
+  let mockDbService: Partial<DbService>;
+  let mockCallsService: Partial<CallsService>;
 
-    beforeEach(async () => {
-        // Reset mocks
-        jest.clearAllMocks();
-        mockRedisClient.set.mockReset();
+  beforeEach(async () => {
+    // Reset mocks
+    jest.clearAllMocks();
+    mockRedisClient.set.mockReset();
 
-        mockDbService = {
-            getUpcomingCallSchedules: jest.fn().mockResolvedValue([]),
-            getMissedCalls: jest.fn().mockResolvedValue([]),
-            getSchedulesForCurrentSlot: jest.fn().mockResolvedValue([]),
-            markReminderSent: jest.fn().mockResolvedValue(undefined),
-        };
+    mockDbService = {
+      getUpcomingCallSchedules: jest.fn().mockResolvedValue([]),
+      getMissedCalls: jest.fn().mockResolvedValue([]),
+      getSchedulesForCurrentSlot: jest.fn().mockResolvedValue([]),
+      markReminderSent: jest.fn().mockResolvedValue(undefined),
+      endStaleCalls: jest.fn().mockResolvedValue(0),
+    };
 
-        mockCallsService = {
-            sendUserPush: jest.fn().mockResolvedValue(undefined),
-            inviteCall: jest.fn().mockResolvedValue({ callId: 'test-call-id', roomName: 'test-room' }),
-        };
+    mockCallsService = {
+      sendUserPush: jest.fn().mockResolvedValue(undefined),
+      inviteCall: jest
+        .fn()
+        .mockResolvedValue({ callId: 'test-call-id', roomName: 'test-room' }),
+    };
 
-        // Set REDIS_URL for tests
-        process.env.REDIS_URL = 'redis://localhost:6379';
+    // Set REDIS_URL for tests
+    process.env.REDIS_URL = 'redis://localhost:6379';
 
-        const module: TestingModule = await Test.createTestingModule({
-            providers: [
-                NotificationScheduler,
-                { provide: DbService, useValue: mockDbService },
-                { provide: CallsService, useValue: mockCallsService },
-            ],
-        }).compile();
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        NotificationScheduler,
+        { provide: DbService, useValue: mockDbService },
+        { provide: CallsService, useValue: mockCallsService },
+      ],
+    }).compile();
 
-        scheduler = module.get<NotificationScheduler>(NotificationScheduler);
-        await scheduler.onModuleInit();
+    scheduler = module.get<NotificationScheduler>(NotificationScheduler);
+    await scheduler.onModuleInit();
+  });
+
+  afterEach(async () => {
+    await scheduler.onModuleDestroy();
+  });
+
+  describe('Distributed Lock - tryAcquireLock', () => {
+    it('should acquire lock when Redis SET NX succeeds', async () => {
+      mockRedisClient.set.mockResolvedValue('OK');
+
+      // Access private method via type assertion
+      const result = await (scheduler as any).tryAcquireLock('test:lock:key');
+
+      expect(result).toBe(true);
+      expect(mockRedisClient.set).toHaveBeenCalledWith(
+        'test:lock:key',
+        expect.any(String), // process.pid
+        { NX: true, EX: 300 },
+      );
     });
 
-    afterEach(async () => {
-        await scheduler.onModuleDestroy();
+    it('should fail to acquire lock when key already exists', async () => {
+      mockRedisClient.set.mockResolvedValue(null);
+
+      const result = await (scheduler as any).tryAcquireLock('test:lock:key');
+
+      expect(result).toBe(false);
     });
 
-    describe('Distributed Lock - tryAcquireLock', () => {
-        it('should acquire lock when Redis SET NX succeeds', async () => {
-            mockRedisClient.set.mockResolvedValue('OK');
+    it('should return true when Redis throws error (fallback behavior)', async () => {
+      mockRedisClient.set.mockRejectedValue(
+        new Error('Redis connection error'),
+      );
 
-            // Access private method via type assertion
-            const result = await (scheduler as any).tryAcquireLock('test:lock:key');
+      const result = await (scheduler as any).tryAcquireLock('test:lock:key');
 
-            expect(result).toBe(true);
-            expect(mockRedisClient.set).toHaveBeenCalledWith(
-                'test:lock:key',
-                expect.any(String), // process.pid
-                { NX: true, EX: 300 }
-            );
-        });
+      expect(result).toBe(true); // 에러 시 진행 허용
+    });
+  });
 
-        it('should fail to acquire lock when key already exists', async () => {
-            mockRedisClient.set.mockResolvedValue(null);
+  describe('checkCallReminders - Lock Integration', () => {
+    it('should skip execution when lock already exists', async () => {
+      mockRedisClient.set.mockResolvedValue(null); // Lock exists
 
-            const result = await (scheduler as any).tryAcquireLock('test:lock:key');
+      await scheduler.checkCallReminders();
 
-            expect(result).toBe(false);
-        });
-
-        it('should return true when Redis throws error (fallback behavior)', async () => {
-            mockRedisClient.set.mockRejectedValue(new Error('Redis connection error'));
-
-            const result = await (scheduler as any).tryAcquireLock('test:lock:key');
-
-            expect(result).toBe(true); // 에러 시 진행 허용
-        });
+      expect(mockDbService.getUpcomingCallSchedules).not.toHaveBeenCalled();
     });
 
-    describe('checkCallReminders - Lock Integration', () => {
-        it('should skip execution when lock already exists', async () => {
-            mockRedisClient.set.mockResolvedValue(null); // Lock exists
+    it('should execute when lock acquired', async () => {
+      mockRedisClient.set.mockResolvedValue('OK');
 
-            await scheduler.checkCallReminders();
+      await scheduler.checkCallReminders();
 
-            expect(mockDbService.getUpcomingCallSchedules).not.toHaveBeenCalled();
-        });
+      expect(mockDbService.getUpcomingCallSchedules).toHaveBeenCalled();
+    });
+  });
 
-        it('should execute when lock acquired', async () => {
-            mockRedisClient.set.mockResolvedValue('OK');
+  describe('checkMissedCalls - Lock Integration', () => {
+    it('should skip execution when lock already exists', async () => {
+      mockRedisClient.set.mockResolvedValue(null);
 
-            await scheduler.checkCallReminders();
+      await scheduler.checkMissedCalls();
 
-            expect(mockDbService.getUpcomingCallSchedules).toHaveBeenCalled();
-        });
+      expect(mockDbService.getMissedCalls).not.toHaveBeenCalled();
     });
 
-    describe('checkMissedCalls - Lock Integration', () => {
-        it('should skip execution when lock already exists', async () => {
-            mockRedisClient.set.mockResolvedValue(null);
+    it('should execute when lock acquired', async () => {
+      mockRedisClient.set.mockResolvedValue('OK');
 
-            await scheduler.checkMissedCalls();
+      await scheduler.checkMissedCalls();
 
-            expect(mockDbService.getMissedCalls).not.toHaveBeenCalled();
-        });
+      expect(mockDbService.getMissedCalls).toHaveBeenCalled();
+    });
+  });
 
-        it('should execute when lock acquired', async () => {
-            mockRedisClient.set.mockResolvedValue('OK');
+  describe('initiateScheduledCalls - Lock Integration', () => {
+    it('should skip execution when lock already exists', async () => {
+      mockRedisClient.set.mockResolvedValue(null);
 
-            await scheduler.checkMissedCalls();
+      await scheduler.initiateScheduledCalls();
 
-            expect(mockDbService.getMissedCalls).toHaveBeenCalled();
-        });
+      expect(mockDbService.getSchedulesForCurrentSlot).not.toHaveBeenCalled();
     });
 
-    describe('initiateScheduledCalls - Lock Integration', () => {
-        it('should skip execution when lock already exists', async () => {
-            mockRedisClient.set.mockResolvedValue(null);
+    it('should execute when lock acquired', async () => {
+      mockRedisClient.set.mockResolvedValue('OK');
 
-            await scheduler.initiateScheduledCalls();
+      await scheduler.initiateScheduledCalls();
 
-            expect(mockDbService.getSchedulesForCurrentSlot).not.toHaveBeenCalled();
-        });
+      expect(mockDbService.getSchedulesForCurrentSlot).toHaveBeenCalled();
+    });
+  });
 
-        it('should execute when lock acquired', async () => {
-            mockRedisClient.set.mockResolvedValue('OK');
+  describe('Lock Key Generation', () => {
+    it('should generate correct lock key for reminders', async () => {
+      mockRedisClient.set.mockResolvedValue('OK');
 
-            await scheduler.initiateScheduledCalls();
+      await scheduler.checkCallReminders();
 
-            expect(mockDbService.getSchedulesForCurrentSlot).toHaveBeenCalled();
-        });
+      const lockKeyArg = mockRedisClient.set.mock.calls[0][0];
+      expect(lockKeyArg).toMatch(/^scheduler:reminder:\d+:(00|30)$/);
     });
 
-    describe('Lock Key Generation', () => {
-        it('should generate correct lock key for reminders', async () => {
-            mockRedisClient.set.mockResolvedValue('OK');
+    it('should generate correct lock key for missed calls', async () => {
+      mockRedisClient.set.mockResolvedValue('OK');
 
-            await scheduler.checkCallReminders();
+      await scheduler.checkMissedCalls();
 
-            const lockKeyArg = mockRedisClient.set.mock.calls[0][0];
-            expect(lockKeyArg).toMatch(/^scheduler:reminder:\d+:(00|30)$/);
-        });
-
-        it('should generate correct lock key for missed calls', async () => {
-            mockRedisClient.set.mockResolvedValue('OK');
-
-            await scheduler.checkMissedCalls();
-
-            const lockKeyArg = mockRedisClient.set.mock.calls[0][0];
-            expect(lockKeyArg).toMatch(/^scheduler:missed:\d+$/);
-        });
-
-        it('should generate correct lock key for scheduled calls', async () => {
-            mockRedisClient.set.mockResolvedValue('OK');
-
-            await scheduler.initiateScheduledCalls();
-
-            const lockKeyArg = mockRedisClient.set.mock.calls[0][0];
-            expect(lockKeyArg).toMatch(/^scheduler:call:\d+:\d{2}$/);
-        });
+      const lockKeyArg = mockRedisClient.set.mock.calls[0][0];
+      expect(lockKeyArg).toMatch(/^scheduler:missed:\d+$/);
     });
+
+    it('should generate correct lock key for scheduled calls', async () => {
+      mockRedisClient.set.mockResolvedValue('OK');
+
+      await scheduler.initiateScheduledCalls();
+
+      const lockKeyArg = mockRedisClient.set.mock.calls[0][0];
+      expect(lockKeyArg).toMatch(/^scheduler:call:\d+:\d{2}$/);
+    });
+
+    it('should generate correct lock key for stale cleanup', async () => {
+      mockRedisClient.set.mockResolvedValue('OK');
+
+      await scheduler.cleanupStaleCalls();
+
+      const lockKeyArg = mockRedisClient.set.mock.calls[0][0];
+      expect(lockKeyArg).toMatch(/^scheduler:stale-cleanup:\d+:\d+$/);
+    });
+  });
+
+  describe('cleanupStaleCalls - Lock Integration', () => {
+    it('should skip execution when lock already exists', async () => {
+      mockRedisClient.set.mockResolvedValue(null);
+
+      await scheduler.cleanupStaleCalls();
+
+      expect(mockDbService.endStaleCalls).not.toHaveBeenCalled();
+    });
+
+    it('should execute when lock acquired', async () => {
+      mockRedisClient.set.mockResolvedValue('OK');
+
+      await scheduler.cleanupStaleCalls();
+
+      expect(mockDbService.endStaleCalls).toHaveBeenCalledWith(15);
+    });
+
+    it('should log when stale calls are ended', async () => {
+      mockRedisClient.set.mockResolvedValue('OK');
+      (mockDbService.endStaleCalls as jest.Mock).mockResolvedValue(3);
+
+      await scheduler.cleanupStaleCalls();
+
+      expect(mockDbService.endStaleCalls).toHaveBeenCalledWith(15);
+    });
+  });
 });

--- a/src/scheduler/notification.scheduler.ts
+++ b/src/scheduler/notification.scheduler.ts
@@ -314,16 +314,18 @@ export class NotificationScheduler implements OnModuleInit, OnModuleDestroy {
       return;
     }
 
-    const STALE_THRESHOLD_MINUTES = 15; // Calls can only last 10 minutes, so 15 is generous
+    // 환경 변수로 threshold 관리 (기본값: 15분)
+    const staleThresholdMinutes = parseInt(
+      process.env.STALE_CALL_THRESHOLD_MINUTES || '15',
+      10,
+    );
 
     try {
-      const endedCount = await this.dbService.endStaleCalls(
-        STALE_THRESHOLD_MINUTES,
-      );
+      const result = await this.dbService.endStaleCalls(staleThresholdMinutes);
 
-      if (endedCount > 0) {
+      if (result.count > 0) {
         this.logger.log(
-          `cleanupStaleCalls ended ${endedCount} stale call(s) older than ${STALE_THRESHOLD_MINUTES} minutes`,
+          `cleanupStaleCalls ended ${result.count} stale call(s) older than ${staleThresholdMinutes} minutes callIds=[${result.callIds.join(', ')}]`,
         );
       }
     } catch (error) {

--- a/src/scheduler/notification.scheduler.ts
+++ b/src/scheduler/notification.scheduler.ts
@@ -1,4 +1,9 @@
-import { Injectable, Logger, OnModuleInit, OnModuleDestroy } from '@nestjs/common';
+import {
+  Injectable,
+  Logger,
+  OnModuleInit,
+  OnModuleDestroy,
+} from '@nestjs/common';
 import { Cron, CronExpression } from '@nestjs/schedule';
 import { DbService } from '../database';
 import { CallsService } from '../calls/calls.service';
@@ -19,7 +24,7 @@ export class NotificationScheduler implements OnModuleInit, OnModuleDestroy {
   constructor(
     private readonly dbService: DbService,
     private readonly callsService: CallsService,
-  ) { }
+  ) {}
 
   async onModuleInit() {
     const redisUrl = process.env.REDIS_URL;
@@ -29,7 +34,9 @@ export class NotificationScheduler implements OnModuleInit, OnModuleDestroy {
         await this.redisClient.connect();
         this.logger.log('Redis connected for scheduler distributed lock');
       } catch (error) {
-        this.logger.warn(`Redis connection failed for scheduler lock: ${(error as Error).message}`);
+        this.logger.warn(
+          `Redis connection failed for scheduler lock: ${(error as Error).message}`,
+        );
         this.redisClient = null;
       }
     } else {
@@ -53,10 +60,14 @@ export class NotificationScheduler implements OnModuleInit, OnModuleDestroy {
     }
 
     try {
-      const result = await this.redisClient.set(lockKey, process.pid.toString(), {
-        NX: true, // Only set if not exists
-        EX: this.LOCK_TTL_SECONDS,
-      });
+      const result = await this.redisClient.set(
+        lockKey,
+        process.pid.toString(),
+        {
+          NX: true, // Only set if not exists
+          EX: this.LOCK_TTL_SECONDS,
+        },
+      );
       return result === 'OK';
     } catch (error) {
       this.logger.error(`Lock acquire failed: ${(error as Error).message}`);
@@ -215,7 +226,9 @@ export class NotificationScheduler implements OnModuleInit, OnModuleDestroy {
     const lockKey = `scheduler:call:${slotStartHour}:${String(slotStartMinute).padStart(2, '0')}`;
     const acquired = await this.tryAcquireLock(lockKey);
     if (!acquired) {
-      this.logger.debug(`initiateScheduledCalls skipped - lock exists: ${lockKey}`);
+      this.logger.debug(
+        `initiateScheduledCalls skipped - lock exists: ${lockKey}`,
+      );
       return;
     }
 
@@ -282,6 +295,41 @@ export class NotificationScheduler implements OnModuleInit, OnModuleDestroy {
       if (now - timestamp > this.DUPLICATE_PREVENTION_MS) {
         this.recentlyCalledSchedules.delete(scheduleId);
       }
+    }
+  }
+
+  /**
+   * Stale call 정리: 'answered' 상태에서 오래 지속된 통화를 'ended'로 변경
+   * LiveKit webhook 누락 시 안전망 역할
+   *
+   * 매 5분마다 실행
+   */
+  @Cron(CronExpression.EVERY_5_MINUTES)
+  async cleanupStaleCalls() {
+    const now = new Date();
+    const lockKey = `scheduler:stale-cleanup:${now.getHours()}:${Math.floor(now.getMinutes() / 5) * 5}`;
+    const acquired = await this.tryAcquireLock(lockKey);
+    if (!acquired) {
+      this.logger.debug(`cleanupStaleCalls skipped - lock exists: ${lockKey}`);
+      return;
+    }
+
+    const STALE_THRESHOLD_MINUTES = 15; // Calls can only last 10 minutes, so 15 is generous
+
+    try {
+      const endedCount = await this.dbService.endStaleCalls(
+        STALE_THRESHOLD_MINUTES,
+      );
+
+      if (endedCount > 0) {
+        this.logger.log(
+          `cleanupStaleCalls ended ${endedCount} stale call(s) older than ${STALE_THRESHOLD_MINUTES} minutes`,
+        );
+      }
+    } catch (error) {
+      this.logger.error(
+        `cleanupStaleCalls failed error=${(error as Error).message}`,
+      );
     }
   }
 }


### PR DESCRIPTION
## 📋 변경 사항

- LiveKit webhook 누락 시 통화가 'answered' 상태에서 멈추는 문제 수정
- 두 가지 안전망 추가:
  1. **Webhook fallback**: `room_finished` 웹훅에서 call context 찾지 못할 때 roomName으로 직접 통화 종료
  2. **Scheduler cleanup**: 매 5분마다 15분 이상 'answered' 상태인 통화 자동 종료

### 수정된 파일
- `call.repository.ts`: `endStaleCalls()`, `endCallsByRoomName()` 메서드 추가
- `db.service.ts`: 새 메서드 facade 노출
- `livekit-webhook.controller.ts`: fallback 정리 로직 추가
- `notification.scheduler.ts`: `cleanupStaleCalls()` cron job 추가

## 🔗 관련 이슈

Closes #141

## ✅ 체크리스트
- [x] TypeScript 컴파일 통과
- [x] 단위 테스트 16개 모두 통과
- [x] Prettier 포맷팅 적용