### PR TITLE
fix: 위급 알림 상세정보 조회 및 SSE 타입 수정 (#150)

### DIFF
--- a/src/admin/beneficiaries/beneficiaries.controller.ts
+++ b/src/admin/beneficiaries/beneficiaries.controller.ts
@@ -202,6 +202,58 @@ export class BeneficiariesController {
     };
   }
 
+  /**
+   * Get beneficiary detail by user ID (e.g., kakao_xxx)
+   * Used when participant identity is available but not ward UUID
+   */
+  @Get('by-user/:userId')
+  async detailByUserId(
+    @CurrentAdmin() admin: { organization_id?: string },
+    @Param('userId') userId: string,
+  ): Promise<BeneficiaryDetailResponse> {
+    const organizationId = this.getOrganizationId(admin);
+
+    // Find ward by user ID
+    const ward = await this.dbService.findWardByUserId(userId);
+
+    if (!ward || ward.organization_id !== organizationId) {
+      throw new HttpException(
+        '대상자 정보를 찾을 수 없습니다.',
+        HttpStatus.NOT_FOUND,
+      );
+    }
+
+    const detail = await this.dbService.getOrganizationBeneficiaryDetail({
+      organizationId,
+      beneficiaryId: ward.id,
+    });
+
+    if (!detail) {
+      throw new HttpException(
+        '대상자 정보를 찾을 수 없습니다.',
+        HttpStatus.NOT_FOUND,
+      );
+    }
+
+    return {
+      data: {
+        id: detail.id,
+        name: detail.name,
+        email: detail.email,
+        phoneNumber: detail.phoneNumber,
+        birthDate: detail.birthDate,
+        address: detail.address,
+        gender: detail.gender,
+        type: detail.type,
+        guardian: detail.guardian,
+        diseases: detail.diseases,
+        medication: detail.medication,
+        notes: detail.notes,
+        recentLogs: detail.recentLogs,
+      },
+    };
+  }
+
   @Get(':id/schedule')
   async getSchedule(
     @CurrentAdmin() admin: { organization_id?: string },

--- a/src/admin/beneficiaries/beneficiaries.controller.ts
+++ b/src/admin/beneficiaries/beneficiaries.controller.ts
@@ -203,7 +203,7 @@ export class BeneficiariesController {
   }
 
   /**
-   * Get beneficiary detail by user ID (e.g., kakao_xxx)
+   * Get beneficiary detail by user identity (e.g., kakao_xxx)
    * Used when participant identity is available but not ward UUID
    */
   @Get('by-user/:userId')
@@ -213,8 +213,8 @@ export class BeneficiariesController {
   ): Promise<BeneficiaryDetailResponse> {
     const organizationId = this.getOrganizationId(admin);
 
-    // Find ward by user ID
-    const ward = await this.dbService.findWardByUserId(userId);
+    // Find ward by user identity (e.g., kakao_xxx)
+    const ward = await this.dbService.findWardByUserIdentity(userId);
 
     if (!ward || ward.organization_id !== organizationId) {
       throw new HttpException(

--- a/src/admin/beneficiaries/beneficiaries.controller.ts
+++ b/src/admin/beneficiaries/beneficiaries.controller.ts
@@ -213,6 +213,11 @@ export class BeneficiariesController {
   ): Promise<BeneficiaryDetailResponse> {
     const organizationId = this.getOrganizationId(admin);
 
+    // Validate userId parameter
+    if (!userId || userId.trim().length === 0) {
+      throw new HttpException('Invalid user ID format', HttpStatus.BAD_REQUEST);
+    }
+
     // Find ward by user identity (e.g., kakao_xxx)
     const ward = await this.dbService.findWardByUserIdentity(userId);
 

--- a/src/care-alerts/care-alerts.service.ts
+++ b/src/care-alerts/care-alerts.service.ts
@@ -402,7 +402,7 @@ export class CareAlertsService {
     }
 
     // 2. Organization에게 WebSocket 이벤트
-    if (ward.organization && event.roomName) {
+    if (ward.organization && event.roomName && wardId) {
       this.logger.log(
         `[NOTIFY_WS] wardId=${wardId} organizationId=${ward.organization.id} roomName=${event.roomName}`,
       );
@@ -412,10 +412,14 @@ export class CareAlertsService {
         roomName: event.roomName,
         isDanger: true,
         name: `${event.alertType}:${wardId}`,
-        wardId,
-        wardName,
+        wardId: wardId || undefined,
+        wardName: wardName || undefined,
         alertType: event.alertType,
       });
+    } else if (!wardId) {
+      this.logger.warn(
+        `[NOTIFY_SKIP] wardId not available for room-danger event, roomName=${event.roomName}`,
+      );
     }
 
     const elapsed = Date.now() - notifyStart;

--- a/src/care-alerts/care-alerts.service.ts
+++ b/src/care-alerts/care-alerts.service.ts
@@ -237,7 +237,8 @@ export class CareAlertsService {
       (sum, emotion) => sum + emotionCounts[emotion],
       0,
     );
-    const negativeRatio = Math.round((negativeCount / totalSamples) * 1000) / 1000;
+    const negativeRatio =
+      Math.round((negativeCount / totalSamples) * 1000) / 1000;
 
     // 평균 confidence
     const averageConfidence =
@@ -335,7 +336,13 @@ export class CareAlertsService {
    */
   private async sendNotifications(
     wardId: string,
-    event: { id: string; alertType: string; severity: string; timestamp: Date; roomName: string | null },
+    event: {
+      id: string;
+      alertType: string;
+      severity: string;
+      timestamp: Date;
+      roomName: string | null;
+    },
   ): Promise<void> {
     const notifyStart = Date.now();
 
@@ -368,8 +375,8 @@ export class CareAlertsService {
     // 1. Guardian에게 APNs Push
     if (ward.guardian?.user.devices) {
       const tokens = ward.guardian.user.devices
-        .filter((d) => d.apnsToken)
-        .map((d) => ({ token: d.apnsToken!, env: d.env }));
+        .filter(d => d.apnsToken)
+        .map(d => ({ token: d.apnsToken!, env: d.env }));
 
       if (tokens.length > 0) {
         this.logger.log(
@@ -405,6 +412,9 @@ export class CareAlertsService {
         roomName: event.roomName,
         isDanger: true,
         name: `${event.alertType}:${wardId}`,
+        wardId,
+        wardName,
+        alertType: event.alertType,
       });
     }
 
@@ -480,7 +490,7 @@ export class CareAlertsService {
     ]);
 
     return {
-      alerts: alerts.map((alert) => ({
+      alerts: alerts.map(alert => ({
         id: alert.id,
         wardId: alert.wardId,
         alertType: alert.alertType as AlertType,
@@ -499,7 +509,10 @@ export class CareAlertsService {
   /**
    * 감정 리포트 조회 (Guardian용)
    */
-  async getEmotionReport(wardId: string, date: string): Promise<EmotionReportResponse> {
+  async getEmotionReport(
+    wardId: string,
+    date: string,
+  ): Promise<EmotionReportResponse> {
     this.logger.log(`[GET_EMOTION_REPORT] wardId=${wardId} date=${date}`);
 
     const targetDate = new Date(date);
@@ -543,7 +556,8 @@ export class CareAlertsService {
 
     for (const summary of summaries) {
       totalSamples += summary.totalSamples;
-      totalNegativeRatio += Number(summary.negativeRatio) * summary.totalSamples;
+      totalNegativeRatio +=
+        Number(summary.negativeRatio) * summary.totalSamples;
 
       const dist = summary.emotionDistribution as Record<EmotionType, number>;
       for (const [emotion, ratio] of Object.entries(dist)) {
@@ -560,12 +574,15 @@ export class CareAlertsService {
 
     return {
       date,
-      summaries: summaries.map((s) => ({
+      summaries: summaries.map(s => ({
         id: s.id,
         periodStart: s.periodStart.toISOString(),
         periodEnd: s.periodEnd.toISOString(),
         totalSamples: s.totalSamples,
-        emotionDistribution: s.emotionDistribution as Record<EmotionType, number>,
+        emotionDistribution: s.emotionDistribution as Record<
+          EmotionType,
+          number
+        >,
         averageConfidence: Number(s.averageConfidence),
         negativeRatio: Number(s.negativeRatio),
         dominantEmotion: s.dominantEmotion as EmotionType,

--- a/src/database/db.service.ts
+++ b/src/database/db.service.ts
@@ -539,6 +539,10 @@ export class DbService implements OnModuleDestroy {
     return this.wards.findByUserId(userId);
   }
 
+  async findWardByUserIdentity(identity: string) {
+    return this.wards.findByUserIdentity(identity);
+  }
+
   async findWardById(wardId: string) {
     return this.wards.findById(wardId);
   }

--- a/src/database/repositories/ward.repository.ts
+++ b/src/database/repositories/ward.repository.ts
@@ -132,6 +132,19 @@ export class WardRepository {
     return ward ? toWardRow(ward) : undefined;
   }
 
+  /**
+   * Find ward by user identity (e.g., kakao_xxx)
+   * Used when we have the participant identity from LiveKit but not the user UUID
+   */
+  async findByUserIdentity(identity: string): Promise<WardRow | undefined> {
+    const user = await this.prisma.user.findUnique({
+      where: { identity },
+      include: { ward: true },
+    });
+    if (!user?.ward) return undefined;
+    return toWardRow(user.ward);
+  }
+
   async findById(wardId: string): Promise<WardRow | undefined> {
     const ward = await this.prisma.ward.findUnique({
       where: { id: wardId },

--- a/src/events/events.service.ts
+++ b/src/events/events.service.ts
@@ -20,6 +20,9 @@ export type RoomEvent = {
   identity?: string;
   name?: string;
   isDanger?: boolean;
+  wardId?: string;
+  wardName?: string;
+  alertType?: string;
   timestamp: string;
 };
 

--- a/src/integration/livekit/livekit-webhook.controller.ts
+++ b/src/integration/livekit/livekit-webhook.controller.ts
@@ -142,6 +142,14 @@ export class LiveKitWebhookController {
             roomName: room.name,
           });
 
+          // Clear any danger status when room ends
+          this.eventsService.emit({
+            type: 'room-danger',
+            roomName: room.name,
+            isDanger: false,
+            name: `room-ended:${room.name}`,
+          });
+
           // Trigger call analysis for the room
           setImmediate(async () => {
             try {


### PR DESCRIPTION
## Summary
- by-user 엔드포인트에서 404 에러 수정
- user identity(kakao_xxx 형식)로 ward 조회 가능하도록 개선
- SSE RoomEvent 타입에 wardId, wardName, alertType 필드 추가

## Changes
- findWardByUserIdentity 메서드 추가 (user identity로 ward 조회)
- by-user 엔드포인트가 findWardByUserIdentity 사용하도록 수정
- RoomEvent 타입 확장 (wardId, wardName, alertType 필드 추가)

## Related Issues
Closes #150

