### PR TITLE
[Feature] 대상자 연동 완료 시 실시간 토스트 알림 (Backend)

### DIFF
--- a/src/auth/auth.service.ts
+++ b/src/auth/auth.service.ts
@@ -357,12 +357,16 @@ export class AuthService {
       );
 
       // SSE 이벤트 발행: 대상자 연동 완료 알림
-      this.eventsService.emitWardEvent({
-        type: 'ward-registered',
-        organizationWardId: matchedOrganizationWard.id,
-        organizationId: matchedOrganizationWard.organization_id,
-        wardName: matchedOrganizationWard.name,
-      });
+      try {
+        this.eventsService.emitWardEvent({
+          type: 'ward-registered',
+          organizationWardId: matchedOrganizationWard.id,
+          organizationId: matchedOrganizationWard.organization_id,
+          wardName: matchedOrganizationWard.name ?? '대상자',
+        });
+      } catch (err) {
+        this.logger.error('Failed to emit ward-registered event', err);
+      }
     }
 
     const tokens = await this.issueTokens(user.id, 'ward');

--- a/src/auth/auth.service.ts
+++ b/src/auth/auth.service.ts
@@ -3,6 +3,7 @@ import * as jwt from 'jsonwebtoken';
 import * as crypto from 'crypto';
 import { randomUUID } from 'node:crypto';
 import { DbService } from '../database';
+import { EventsService } from '../events/events.service';
 
 type UserType = 'guardian' | 'ward';
 
@@ -111,7 +112,10 @@ export class AuthService {
   private readonly accessTokenExpiry: number;
   private readonly refreshTokenExpiry: number;
 
-  constructor(private readonly dbService: DbService) {
+  constructor(
+    private readonly dbService: DbService,
+    private readonly eventsService: EventsService,
+  ) {
     const secret = process.env.API_JWT_SECRET || process.env.JWT_SECRET;
     if (!secret) {
       throw new Error(
@@ -165,8 +169,9 @@ export class AuthService {
           existingUser.id,
         );
         if (guardian) {
-          const linkedCount =
-            await this.dbService.linkPendingWardsForGuardian(guardian.id);
+          const linkedCount = await this.dbService.linkPendingWardsForGuardian(
+            guardian.id,
+          );
           if (linkedCount > 0) {
             this.logger.log(
               `kakaoLogin auto-linked ${linkedCount} wards for guardian=${guardian.id}`,
@@ -350,6 +355,14 @@ export class AuthService {
       this.logger.log(
         `Auto-linked ward=${ward.id} to organization=${matchedOrganizationWard.organization_id}`,
       );
+
+      // SSE 이벤트 발행: 대상자 연동 완료 알림
+      this.eventsService.emitWardEvent({
+        type: 'ward-registered',
+        organizationWardId: matchedOrganizationWard.id,
+        organizationId: matchedOrganizationWard.organization_id,
+        wardName: matchedOrganizationWard.name,
+      });
     }
 
     const tokens = await this.issueTokens(user.id, 'ward');
@@ -517,14 +530,15 @@ export class AuthService {
     }
 
     // 4. 트랜잭션으로 사용자 타입 변경 + 보호자 정보 + 어르신 등록 정보 생성
-    const { guardian, registration } = await this.dbService.registerGuardianWithTransaction({
-      userId: user.id,
-      wardEmail: params.wardEmail,
-      wardPhoneNumber: params.wardPhoneNumber,
-      wardBasicInfo: params.wardBasicInfo,
-      aiCareInfo: params.aiCareInfo,
-      callSchedule: params.callSchedule,
-    });
+    const { guardian, registration } =
+      await this.dbService.registerGuardianWithTransaction({
+        userId: user.id,
+        wardEmail: params.wardEmail,
+        wardPhoneNumber: params.wardPhoneNumber,
+        wardBasicInfo: params.wardBasicInfo,
+        aiCareInfo: params.aiCareInfo,
+        callSchedule: params.callSchedule,
+      });
 
     // 5. 새 JWT 발급 (user_type이 변경되었으므로)
     const tokens = await this.issueTokens(user.id, 'guardian');
@@ -631,7 +645,7 @@ export class AuthService {
         },
         guardianInfo: {
           id: existingGuardian.id,
-          wards: wards.map((w) => ({
+          wards: wards.map(w => ({
             registrationId: w.id,
             wardEmail: w.ward_email,
             wardPhoneNumber: w.ward_phone_number,

--- a/src/database/repositories/ward.repository.ts
+++ b/src/database/repositories/ward.repository.ts
@@ -533,6 +533,7 @@ export class WardRepository {
       organization_id: orgWard.organizationId,
       email: orgWard.email,
       phone_number: orgWard.phoneNumber,
+      name: orgWard.name,
     };
   }
 
@@ -1119,7 +1120,14 @@ export class WardRepository {
       include: {
         ward: {
           include: {
-            user: { select: { id: true, identity: true, displayName: true, nickname: true } },
+            user: {
+              select: {
+                id: true,
+                identity: true,
+                displayName: true,
+                nickname: true,
+              },
+            },
           },
         },
       },
@@ -1131,7 +1139,10 @@ export class WardRepository {
       .map(s => ({
         scheduleId: s.id,
         wardId: s.wardId!,
-        wardName: s.ward!.user.displayName ?? s.ward!.user.nickname ?? s.ward!.user.identity,
+        wardName:
+          s.ward!.user.displayName ??
+          s.ward!.user.nickname ??
+          s.ward!.user.identity,
         wardIdentity: s.ward!.user.identity,
         aiPersona: s.ward!.aiPersona ?? '다미',
         slotStartHour: s.slotStartHour,

--- a/src/events/events.service.ts
+++ b/src/events/events.service.ts
@@ -26,7 +26,15 @@ export type RoomEvent = {
   timestamp: string;
 };
 
-export type AppEvent = UserEvent | RoomEvent;
+export type WardEvent = {
+  type: 'ward-registered';
+  organizationWardId: string;
+  organizationId: string;
+  wardName: string;
+  timestamp: string;
+};
+
+export type AppEvent = UserEvent | RoomEvent | WardEvent;
 
 @Injectable()
 export class EventsService {
@@ -35,14 +43,27 @@ export class EventsService {
   private subscriberCount = 0;
 
   emit(
-    event: Omit<UserEvent, 'timestamp'> | Omit<RoomEvent, 'timestamp'>,
+    event:
+      | Omit<UserEvent, 'timestamp'>
+      | Omit<RoomEvent, 'timestamp'>
+      | Omit<WardEvent, 'timestamp'>,
   ): void {
     const fullEvent = {
       ...event,
       timestamp: new Date().toISOString(),
     } as AppEvent;
+
+    let logDetail = '';
+    if ('roomName' in fullEvent) {
+      logDetail = `room=${fullEvent.roomName}`;
+    } else if ('identity' in fullEvent) {
+      logDetail = `identity=${fullEvent.identity}`;
+    } else if ('organizationWardId' in fullEvent) {
+      logDetail = `organizationWardId=${fullEvent.organizationWardId} wardName=${fullEvent.wardName}`;
+    }
+
     this.logger.log(
-      `Emitting event: type=${fullEvent.type} ${'roomName' in fullEvent ? `room=${fullEvent.roomName}` : `identity=${fullEvent.identity}`} subscribers=${this.subscriberCount}`,
+      `Emitting event: type=${fullEvent.type} ${logDetail} subscribers=${this.subscriberCount}`,
     );
     this.events$.next(fullEvent);
   }
@@ -52,6 +73,10 @@ export class EventsService {
   }
 
   emitRoomEvent(event: Omit<RoomEvent, 'timestamp'>): void {
+    this.emit(event);
+  }
+
+  emitWardEvent(event: Omit<WardEvent, 'timestamp'>): void {
     this.emit(event);
   }
 


### PR DESCRIPTION
## 📋 변경 사항

- `WardEvent` SSE 이벤트 타입 추가 (`ward-registered`)
- `emitWardEvent()` 메서드 추가
- 카카오 로그인 시 기관 대상자 연동 완료 이벤트 발행
- `findPendingOrganizationWardByEmail`에서 `name` 필드 반환 추가

## 🔗 관련 이슈

Closes #151

## ✅ 체크리스트
- [x] prettier 적용
- [x] 브랜치/커밋 규칙 준수